### PR TITLE
[N/A] Added SingleGoalMultipleActionServers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,39 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# colcon
+build/
+install/
+log/
+
+# catkin_make
+devel/
+logs/
+build/
+bin/
+lib/
+
+# Editors
+.idea/
+.vscode/
+*~
+*\#*
+.#*
+
+# ROS
+bag_files/
+
+# Misc
+.DS_Store
+cyclonedds.xml
+
+# ROS bags
+*.db3
+*.bag
+
+# wandb
+wandb/
+
+# Gitman-tracked external repos
+external

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/service_client.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/service_client.py
@@ -2,7 +2,7 @@
 from typing import Optional
 
 from rclpy import Context
-from rclpy.client import SrvType, SrvTypeRequest, SrvTypeResponse
+from rclpy.service import SrvType, SrvTypeRequest, SrvTypeResponse
 
 from bdai_ros2_wrappers.node import NodeWrapper
 

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/single_goal_multiple_action_servers.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/single_goal_multiple_action_servers.py
@@ -12,6 +12,10 @@ from bdai_ros2_wrappers.type_hints import Action, ActionType
 
 
 class SingleGoalMultipleActionServers(object):
+    """Wrapper around multiple action servers that only allows a single Action to be executing at one time. If a new
+    Action.Goal is received by any of the action servers, the existing Action (if there is one) is preemptively
+    canceled"""
+
     def __init__(
         self, node: Node, action_server_parameters: List[Tuple[ActionType, str, Callable, Optional[CallbackGroup]]]
     ) -> None:
@@ -57,6 +61,6 @@ class SingleGoalMultipleActionServers(object):
         goal_handle.execute()
 
     def cancel_callback(self, cancel_request: Any) -> CancelResponse:
-        """Accept or reject a client request to cancel an action."""
+        """Accept or reject a client's request to cancel an action."""
         self.get_logger().info("Received cancel request")
         return CancelResponse.ACCEPT

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/single_goal_multiple_action_servers.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/single_goal_multiple_action_servers.py
@@ -1,11 +1,12 @@
 #  Copyright (c) 2023 Boston Dynamics AI Institute, Inc. All rights reserved.
 import threading
-from typing import Tuple, Callable, TypeVar, List, Optional
+from typing import Any, Callable, List, Optional, Tuple
 
-from rclpy import Node
-from rclpy.action import ActionServer, GoalResponse, CancelResponse
+from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.action.server import ServerGoalHandle
 from rclpy.callback_groups import CallbackGroup
+from rclpy.impl.rcutils_logger import RcutilsLogger
+from rclpy.node import Node
 
 from bdai_ros2_wrappers.type_hints import Action, ActionType
 
@@ -15,7 +16,7 @@ class SingleGoalMultipleActionServers(object):
         self, node: Node, action_server_parameters: List[Tuple[ActionType, str, Callable, Optional[CallbackGroup]]]
     ) -> None:
         self._node = node
-        self._goal_handle = None
+        self._goal_handle: Optional[ServerGoalHandle] = None
         self._goal_lock = threading.Lock()
         self._action_servers = []
         for action_type, action_topic, execute_callback, callback_group in action_server_parameters:
@@ -32,7 +33,7 @@ class SingleGoalMultipleActionServers(object):
                 )
             )
 
-    def get_logger(self):
+    def get_logger(self) -> RcutilsLogger:
         return self._node.get_logger()
 
     def destroy(self) -> None:
@@ -55,7 +56,7 @@ class SingleGoalMultipleActionServers(object):
 
         goal_handle.execute()
 
-    def cancel_callback(self, cancel_request) -> CancelResponse:
+    def cancel_callback(self, cancel_request: Any) -> CancelResponse:
         """Accept or reject a client request to cancel an action."""
         self.get_logger().info("Received cancel request")
         return CancelResponse.ACCEPT

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/single_goal_multiple_action_servers.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/single_goal_multiple_action_servers.py
@@ -1,0 +1,61 @@
+#  Copyright (c) 2023 Boston Dynamics AI Institute, Inc. All rights reserved.
+import threading
+from typing import Tuple, Callable, TypeVar, List, Optional
+
+from rclpy import Node
+from rclpy.action import ActionServer, GoalResponse, CancelResponse
+from rclpy.action.server import ServerGoalHandle
+from rclpy.callback_groups import CallbackGroup
+
+from bdai_ros2_wrappers.type_hints import Action, ActionType
+
+
+class SingleGoalMultipleActionServers(object):
+    def __init__(
+        self, node: Node, action_server_parameters: List[Tuple[ActionType, str, Callable, Optional[CallbackGroup]]]
+    ) -> None:
+        self._node = node
+        self._goal_handle = None
+        self._goal_lock = threading.Lock()
+        self._action_servers = []
+        for action_type, action_topic, execute_callback, callback_group in action_server_parameters:
+            self._action_servers.append(
+                ActionServer(
+                    node,
+                    action_type,
+                    action_topic,
+                    execute_callback=execute_callback,
+                    goal_callback=self.goal_callback,
+                    handle_accepted_callback=self.handle_accepted_callback,
+                    cancel_callback=self.cancel_callback,
+                    callback_group=callback_group,
+                )
+            )
+
+    def get_logger(self):
+        return self._node.get_logger()
+
+    def destroy(self) -> None:
+        for action_server in self._action_servers:
+            action_server.destroy()
+
+    def goal_callback(self, goal: Action.Goal) -> GoalResponse:
+        """Accept or reject a client request to begin an action."""
+        self.get_logger().info("Received goal request")
+        return GoalResponse.ACCEPT
+
+    def handle_accepted_callback(self, goal_handle: ServerGoalHandle) -> None:
+        with self._goal_lock:
+            # This server only allows one goal at a time
+            if self._goal_handle is not None and self._goal_handle.is_active:
+                self.get_logger().info("Aborting previous goal")
+                # Abort the existing goal
+                self._goal_handle.abort()
+            self._goal_handle = goal_handle
+
+        goal_handle.execute()
+
+    def cancel_callback(self, cancel_request) -> CancelResponse:
+        """Accept or reject a client request to cancel an action."""
+        self.get_logger().info("Received cancel request")
+        return CancelResponse.ACCEPT

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/type_hints.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/type_hints.py
@@ -1,0 +1,22 @@
+#  Copyright (c) 2023 Boston Dynamics AI Institute, Inc. All rights reserved.
+from typing import TypeVar
+
+# The specific Action is created by the .action file
+Action = TypeVar("Action")
+Action_Goal = TypeVar("Action_Goal")
+Action_Feedback = TypeVar("Action_Feedback")
+Action_Result = TypeVar("Action_Result")
+
+# Use for type hints where you are passing the type of an action, not an action object
+ActionType = TypeVar("ActionType")
+
+# The actual code generated for actions does something like this
+Action.Goal = Action_Goal  # type: ignore
+Action.Feedback = Action_Feedback  # type: ignore
+Action.Result = Action_Result  # type: ignore
+
+# The specific Msg is created by the .msg file
+Msg = TypeVar("Msg")
+
+# The specific Srv is created by the .srv file
+Srv = TypeVar("Srv")

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/type_hints.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/type_hints.py
@@ -17,6 +17,3 @@ Action.Result = Action_Result  # type: ignore
 
 # The specific Msg is created by the .msg file
 Msg = TypeVar("Msg")
-
-# The specific Srv is created by the .srv file
-Srv = TypeVar("Srv")


### PR DESCRIPTION
In spot_ros2, there are multiple action servers, namely RobotCommand and Manipulation, that cause spot to stop executing its current action and proceed executing the new action (not a ROS action, but the thing that spot is doing). Previously, when RobotCommand was the only action server this could be handled through the SingleGoalActionServer, so ROS would know that the preemption was happening and reflect that. This extends that idea by creating a class to wrap multiple action servers, so any action sent to any of the action servers preempts the action that is currently executing regardless of which action server is executing. Will be used in spot_ros2 initially for the RobotCommand and Manipulation action servers.

Additionally, I updated the TFListenerWrapper to run its own spin thread, so we can handle exceptions (particularly the ExternalShutdownException as that was prohibiting clean shutdown on the HIL test).

Third, some minor type hint updates.