### PR TITLE
[N/A]  Added spin thread design pattern to NodeWrapper

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/__init__.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/__init__.py
@@ -1,1 +1,1 @@
-# Copyright [2023] Boston Dynamics AI Institute, Inc.
+# Copyright (c) 2023 Boston Dynamics AI Institute, Inc.  All rights reserved.

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
@@ -1,4 +1,4 @@
-# Copyright [2023] Boston Dynamics AI Institute, Inc.
+# Copyright (c) 2023 Boston Dynamics AI Institute, Inc.  All rights reserved.
 from typing import Any, Optional
 
 import rclpy.action
@@ -19,7 +19,7 @@ class ActionClientWrapper(rclpy.action.ActionClient):
         self._node_wrapper = NodeWrapper(
             f"{node_name}_{action_name}_client_wrapper_node", namespace=namespace, context=context
         )
-        super().__init__(self._node_wrapper.node, action_type, action_name)
+        super().__init__(self._node_wrapper, action_type, action_name)
         self._node_wrapper.node.get_logger().info(
             "Waiting for action server for " + self._node.get_namespace() + "/" + action_name
         )

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/future.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/future.py
@@ -1,0 +1,18 @@
+#  Copyright (c) 2023 Boston Dynamics AI Institute, Inc.  All rights reserved.
+from threading import Event
+from typing import Any, Optional
+
+from rclpy.task import Future
+
+
+def wait_until_future_complete(future: Future, timeout_sec: Optional[float] = None) -> Any:
+    """Waits for a future assuming that the node which created the future is spinning somewhere else"""
+    event = Event()
+
+    def _done_callback(_: Any) -> None:
+        event.set()
+
+    future.add_done_callback(_done_callback)
+    if not event.wait(timeout=timeout_sec):
+        raise TimeoutError("Future did not complete in time")
+    return future.result

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/node.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/node.py
@@ -1,22 +1,59 @@
-# Copyright [2023] Boston Dynamics AI Institute, Inc.
+# Copyright (c) 2023 Boston Dynamics AI Institute, Inc.  All rights reserved.
+from threading import Thread
 from typing import Any, Optional
 
 from rclpy import Context, Future
-from rclpy.executors import SingleThreadedExecutor
+from rclpy.executors import ExternalShutdownException, MultiThreadedExecutor, SingleThreadedExecutor
 from rclpy.node import Node
 
+from bdai_ros2_wrappers.future import wait_until_future_complete
 
-class NodeWrapper:
-    """A wrapper around a node and its executor. The node is spun by the executor when calling
-    spin_until_future_complete, which allows a future to be spun inside a callback."""
 
-    def __init__(self, node_name: str, namespace: Optional[str] = None, context: Optional[Context] = None) -> None:
-        self.node = Node(node_name, namespace=namespace, context=context)
-        self.__executor = SingleThreadedExecutor(context=context)
-        self.__executor.add_node(self.node)
+class NodeWrapper(Node):
+    """A wrapper around a node and its executor."""
+
+    def __init__(
+        self,
+        node_name: str,
+        *,
+        context: Optional[Context] = None,
+        namespace: Optional[str] = None,
+        spin_thread: bool = False,
+        num_executor_threads: int = 1,
+    ) -> None:
+        super().__init__(node_name, context=context, namespace=namespace)
+
+        if num_executor_threads == 1:
+            self._executor = SingleThreadedExecutor(context=context)
+        else:
+            self._executor = MultiThreadedExecutor(context=context)
+        self._executor.add_node(self)
+
+        if spin_thread:
+            self._thread: Optional[Thread] = Thread(target=self._spin)
+            self._thread.start()
+        else:
+            self._thread = None
+
+    def _spin(self) -> None:
+        try:
+            self._executor.spin()
+        except (KeyboardInterrupt, ExternalShutdownException):
+            pass
 
     def spin_until_future_complete(self, future: Future, timeout_sec: Optional[float] = None) -> Any:
         """Spin the internal node until the future completes, and return the result. This is safe to call from a
         callback."""
-        self.__executor.spin_until_future_complete(future, timeout_sec=timeout_sec)
+        if self._thread is not None:
+            wait_until_future_complete(future, timeout_sec=timeout_sec)
+        else:
+            self._executor.spin_until_future_complete(future, timeout_sec=timeout_sec)
+
         return future.result()
+
+    def shutdown(self) -> None:
+        self._executor.shutdown()
+        self._executor.remove_node(self)
+        if self._thread is not None:
+            self._thread.join()
+        self.destroy_node()

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/service_client.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/service_client.py
@@ -1,4 +1,4 @@
-# Copyright [2023] Boston Dynamics AI Institute, Inc.
+# Copyright (c) 2023 Boston Dynamics AI Institute, Inc.  All rights reserved.
 from typing import Optional
 
 from rclpy import Context
@@ -14,9 +14,9 @@ class ServiceClientWrapper:
     def __init__(
         self, node_name: str, service_type: SrvType, service_name: str, context: Optional[Context] = None
     ) -> None:
-        self._node_wrapper = NodeWrapper(node_name, context=context)
+        self._node_wrapper = NodeWrapper(node_name, context=context, spin_thread=False)
         self._service_name = service_name
-        self._client = self._node_wrapper.node.create_client(service_type, service_name)
+        self._client = self._node_wrapper.create_client(service_type, service_name)
 
     def call(
         self,
@@ -27,11 +27,11 @@ class ServiceClientWrapper:
         """Calls the service and returns the result. This is safe to call from a callback."""
         wait_for_service_attempts = 0
         while not self._client.wait_for_service(timeout_sec=timeout_sec):
-            self._node_wrapper.node.get_logger().warn(f"{self._service_name} not available, waiting again...")
+            self._node_wrapper.get_logger().warn(f"{self._service_name} not available, waiting again...")
             wait_for_service_attempts += 1
 
             if max_wait_for_service_attempts is not None and wait_for_service_attempts >= max_wait_for_service_attempts:
-                self._node_wrapper.node.get_logger().error(f"{self._service_name} not available!")
+                self._node_wrapper.get_logger().error(f"{self._service_name} not available!")
                 return None
 
         future = self._client.call_async(request)

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/single_goal_action_server.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/single_goal_action_server.py
@@ -1,4 +1,4 @@
-# Copyright [2023] Boston Dynamics AI Institute, Inc.
+# Copyright (c) 2023 Boston Dynamics AI Institute, Inc.  All rights reserved.
 
 from typing import Callable, Optional
 

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/type_hints.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/type_hints.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023 Boston Dynamics AI Institute, Inc. All rights reserved.
+# Copyright (c) 2023 Boston Dynamics AI Institute, Inc.  All rights reserved.
 from typing import TypeVar
 
 # The specific Action is created by the .action file

--- a/bdai_ros2_wrappers/setup.cfg
+++ b/bdai_ros2_wrappers/setup.cfg
@@ -1,4 +1,4 @@
-# Copyright [2023] Boston Dynamics AI Institute, Inc.
+# Copyright (c) 2023 Boston Dynamics AI Institute, Inc.  All rights reserved.
 
 [develop]
 script_dir=$base/lib/bdai_ros2_wrappers

--- a/bdai_ros2_wrappers/setup.py
+++ b/bdai_ros2_wrappers/setup.py
@@ -1,4 +1,4 @@
-# Copyright [2023] Boston Dynamics AI Institute, Inc.
+# Copyright (c) 2023 Boston Dynamics AI Institute, Inc.  All rights reserved.
 
 from setuptools import setup
 

--- a/bdai_ros2_wrappers/tests/test_tf_listener_wrapper.py
+++ b/bdai_ros2_wrappers/tests/test_tf_listener_wrapper.py
@@ -1,17 +1,17 @@
-# Copyright [2023] Boston Dynamics AI Institute, Inc.
-
-import asyncio
+# Copyright (c) 2023 Boston Dynamics AI Institute, Inc.  All rights reserved.
 import time
-from typing import Optional, Union
+import unittest
+from threading import Thread
+from typing import Optional
 
-import numpy.typing as npt
-import pytest
 import rclpy
-import tf2_ros
 from geometry_msgs.msg import Quaternion, Transform, TransformStamped, Vector3
+from rclpy import Context
 from rclpy.duration import Duration
+from rclpy.executors import ExternalShutdownException, SingleThreadedExecutor
 from rclpy.node import Node
 from rclpy.time import Time
+from tf2_ros import ExtrapolationException, LookupException, TransformBroadcaster
 
 from bdai_ros2_wrappers.tf_listener_wrapper import TFListenerWrapper
 
@@ -21,254 +21,167 @@ FRAME_ID = f"{ROBOT}/body"
 CHILD_FRAME_ID = f"{ROBOT}/{CAMERA}"
 
 
-class MockTFPublisher(Node):
-    def __init__(self, frame_id: str, child_frame_id: str) -> None:
-        super().__init__("mock_tf_publisher")
+def equal_transform(a: Transform, b: Transform) -> bool:
+    return (
+        a.translation.x == b.translation.x
+        and a.translation.y == b.translation.y
+        and a.translation.z == b.translation.z
+        and a.rotation.w == b.rotation.w
+        and a.rotation.x == b.rotation.x
+        and a.rotation.y == b.rotation.y
+        and a.rotation.z == a.rotation.z
+    )
 
-        self.frame_id = frame_id
-        self.child_frame_id = child_frame_id
 
-        self.tf_broadcaster = tf2_ros.TransformBroadcaster(self)
+class MockTfPublisherNode(Node):
+    def __init__(self, context: Context, frame_id: str, child_frame_id: str) -> None:
+        super().__init__("mock_tf_publisher", context=context)
 
-    def publish_transform(
-        self,
-        translation: npt.ArrayLike,
-        rotation: npt.ArrayLike,
-        timestamp: Time,
-    ) -> None:
+        self._frame_id = frame_id
+        self._child_frame_id = child_frame_id
+        self._tf_broadcaster = TransformBroadcaster(self)
+        self._executor: Optional[SingleThreadedExecutor] = SingleThreadedExecutor(context=context)
+        self._executor.add_node(self)
+        self._thread: Optional[Thread] = Thread(target=self._spin)
+        self._thread.start()
+
+    def _spin(self) -> None:
+        if self._executor is not None:
+            try:
+                self._executor.spin()
+            except (ExternalShutdownException, KeyboardInterrupt):
+                pass
+
+    def publish_transform(self, trans: Transform, timestamp: Optional[Time]) -> None:
         t = TransformStamped()
 
-        t.header.stamp = timestamp.to_msg()
-        t.header.frame_id = self.frame_id
-        t.child_frame_id = self.child_frame_id
+        if timestamp is not None:
+            t.header.stamp = timestamp.to_msg()
+        t.header.frame_id = self._frame_id
+        t.child_frame_id = self._child_frame_id
 
-        t.transform = Transform(
-            translation=Vector3(x=translation[0], y=translation[1], z=translation[2]),
-            rotation=Quaternion(w=rotation[0], x=rotation[1], y=rotation[2], z=rotation[3]),
+        t.transform = trans
+
+        self._tf_broadcaster.sendTransform(t)
+
+    def shutdown(self) -> None:
+        if self._tf_broadcaster is not None:
+            self._tf_broadcaster = None
+        if self._executor is not None:
+            self._executor.shutdown()
+            self._executor.remove_node(self)
+            self._executor = None
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+        self.destroy_node()
+
+
+class TfListenerWrapperTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.context: Optional[Context] = Context()
+        rclpy.init(context=self.context)
+        self.tf_publisher: Optional[MockTfPublisherNode] = MockTfPublisherNode(self.context, FRAME_ID, CHILD_FRAME_ID)
+        self.tf_listener: Optional[TFListenerWrapper] = TFListenerWrapper(node_name="test", context=self.context)
+
+    def tearDown(self) -> None:
+        if self.tf_listener is not None:
+            self.tf_listener.shutdown()
+            self.tf_listener = None
+        if self.tf_publisher is not None:
+            self.tf_publisher.shutdown()
+            self.tf_publisher = None
+        rclpy.shutdown(context=self.context)
+        self.context = None
+
+    def test_non_existant_transform(self) -> None:
+        if self.tf_listener is None or self.tf_publisher is None:
+            self.fail()
+        timestamp = self.tf_publisher.get_clock().now()
+        self.assertRaises(LookupException, self.tf_listener.lookup_a_tform_b, FRAME_ID, CHILD_FRAME_ID, timestamp)
+
+    def test_non_existant_transform_timeout(self) -> None:
+        if self.tf_listener is None or self.tf_publisher is None:
+            self.fail()
+        timestamp = self.tf_publisher.get_clock().now()
+        start = time.time()
+        self.assertRaises(
+            LookupException, self.tf_listener.lookup_a_tform_b, FRAME_ID, CHILD_FRAME_ID, timestamp, timeout=20.0
+        )
+        self.assertLess(time.time() - start, 10.0)
+
+    def test_existing_transform(self) -> None:
+        if self.tf_listener is None or self.tf_publisher is None:
+            self.fail()
+        timestamp = self.tf_publisher.get_clock().now()
+        trans = Transform(translation=Vector3(x=1.0, y=2.0, z=3.0), rotation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))
+        self.tf_publisher.publish_transform(trans, timestamp)
+        time.sleep(0.2)
+        t = self.tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp)
+        self.assertTrue(equal_transform(t.transform, trans))
+
+    def test_future_transform_extrapolation_exception(self) -> None:
+        if self.tf_listener is None or self.tf_publisher is None:
+            self.fail()
+        timestamp = self.tf_publisher.get_clock().now()
+        trans = Transform(translation=Vector3(x=1.0, y=2.0, z=3.0), rotation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))
+        self.tf_publisher.publish_transform(trans, timestamp)
+        time.sleep(0.2)
+        timestamp = self.tf_publisher.get_clock().now()
+        self.assertRaises(
+            ExtrapolationException, self.tf_listener.lookup_a_tform_b, FRAME_ID, CHILD_FRAME_ID, timestamp
         )
 
-        self.tf_broadcaster.sendTransform(t)
+    def test_future_transform_insufficient_wait(self) -> None:
+        if self.tf_listener is None or self.tf_publisher is None:
+            self.fail()
+        timestamp = self.tf_publisher.get_clock().now()
+        trans = Transform(translation=Vector3(x=1.0, y=2.0, z=3.0), rotation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))
+        self.tf_publisher.publish_transform(trans, timestamp)
 
-    async def publish_transform_async(
-        self,
-        translation: Optional[npt.ArrayLike] = None,
-        rotation: Optional[npt.ArrayLike] = None,
-        timestamp: Optional[Time] = None,
-        delay: int = 0,
-    ) -> None:
-        if rotation is None:
-            rotation = [1, 0, 0, 0]
-        if translation is None:
-            translation = [0, 0, 0]
-        if delay > 0:
-            await asyncio.sleep(delay)
+        delay = 2
 
-        self.publish_transform(translation, rotation, timestamp)
+        def _delayed_publish() -> None:
+            if self.tf_publisher is None:
+                self.fail()
+            time.sleep(delay)
+            delayed_timestamp = self.tf_publisher.get_clock().now()
+            self.tf_publisher.publish_transform(trans, delayed_timestamp)
 
+        thread = Thread(target=_delayed_publish)
+        thread.start()
 
-def check_tf_lookup(
-    tf_listener: TFListenerWrapper,
-    translation: npt.ArrayLike,
-    rotation: npt.ArrayLike,
-    timestamp: Time,
-    timeout: Union[float, int] = 0,
-    wait_for_frames: bool = False,
-) -> None:
-    try:
-        t = tf_listener.lookup_a_tform_b(
-            FRAME_ID,
-            CHILD_FRAME_ID,
-            timestamp,
-            timeout=timeout,
-            wait_for_frames=wait_for_frames,
-        ).transform
-
-        assert t.translation.x == translation[0]
-        assert t.translation.y == translation[1]
-        assert t.translation.z == translation[2]
-
-        assert t.rotation.w == rotation[0]
-        assert t.rotation.x == rotation[1]
-        assert t.rotation.y == rotation[2]
-        assert t.rotation.z == rotation[3]
-
-    except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException) as err:
-        raise err
-
-
-# I do not know if this is the best way to test asynchronous routines. We may want to do this with
-# multiple nodes and service calls to synchronize the message passing.
-async def delayed_lookup(
-    tf_publisher: MockTFPublisher,
-    tf_listener: TFListenerWrapper,
-    translation: npt.ArrayLike,
-    rotation: npt.ArrayLike,
-    delay_sec: int = 0,
-    timeout: Union[float, int] = 0,
-    wait_for_frames: bool = False,
-    check_init: bool = False,
-) -> None:
-    timestamp = tf_publisher.get_clock().now()
-    timestamp += Duration(seconds=delay_sec)
-    loop = asyncio.get_event_loop()
-    delay_task = loop.create_task(tf_publisher.publish_transform_async(translation, rotation, timestamp, delay_sec))
-
-    await asyncio.sleep(0)
-    try:
-        if not check_init:
-            await loop.run_in_executor(
-                None, lambda: check_tf_lookup(tf_listener, translation, rotation, timestamp, timeout, wait_for_frames)
-            )
-        else:
-            await loop.run_in_executor(None, lambda: tf_listener.wait_for_init(FRAME_ID, CHILD_FRAME_ID))
-    finally:
-        # I do not know if this is necessary
-        await delay_task
-
-
-# Using the pytest feature allows us to clean up the listener so this doesn't hang at the end
-@pytest.fixture
-def tf_listener() -> TFListenerWrapper:
-    args = ["test", "--ros-args", "-p", f"robot:={ROBOT}"]
-    rclpy.init(args=args)
-
-    _tf_listener = TFListenerWrapper("mock_tf_wrapper")
-    yield _tf_listener
-    # We have to do this to make sure the test exits cleanly even if it fails
-    _tf_listener.shutdown()
-    rclpy.shutdown()
-
-
-def test_tf_listener_wrapper(tf_listener: TFListenerWrapper) -> None:
-    """
-    Unit tests for the TFListenerWrapper class
-    """
-
-    tf_publisher = MockTFPublisher(FRAME_ID, CHILD_FRAME_ID)
-
-    rclpy.spin_once(tf_publisher, timeout_sec=0.01)
-
-    # Non-existent transform throws LookupException
-    print()
-    print("Looking up nonexisting transform")
-    timestamp = tf_publisher.get_clock().now()
-    lookup_err = None
-    try:
-        trans = tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp)
-    except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException) as err:
-        lookup_err = err
-    assert isinstance(lookup_err, tf2_ros.LookupException)
-    print("LookupException Thrown")
-
-    # A non-existent transform with a timeout but without wait_for_frames returns a LookupException immediately
-    # (Time-based tests can be flaky but in this case we're trying to tell the difference between 20s and immediately
-    #  so hopefully we'll be ok.)
-    print()
-    print("Looking up nonexisting transform with a timeout but without wait_for_frames")
-    timestamp = tf_publisher.get_clock().now()
-    lookup_err = None
-    start = time.time()
-    try:
-        trans = tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp, timeout=20.0)
-    except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException) as err:
-        lookup_err = err
-    end = time.time()
-    assert isinstance(lookup_err, tf2_ros.LookupException)
-    print("LookupException Thrown")
-    assert end - start < 10.0
-
-    # A non-existent transform with a timeout but with wait_for_frames properly waits
-    print()
-    print("Waiting for a non-existent transform that eventually comes in")
-    asyncio.run(
-        delayed_lookup(
-            tf_publisher,
-            tf_listener,
-            [4.0, 5.0, 6.0],
-            [0.0, 1.0, 0.0, 0.0],
-            delay_sec=2,
-            timeout=5.0,
-            wait_for_frames=True,
+        time.sleep(0.2)
+        timestamp = self.tf_publisher.get_clock().now() + Duration(seconds=delay)
+        self.assertRaises(
+            ExtrapolationException, self.tf_listener.lookup_a_tform_b, FRAME_ID, CHILD_FRAME_ID, timestamp, timeout=0.5
         )
-    )
+        thread.join()
 
-    # Existing transform returns correctly
-    print()
-    print("Looking up existing transform")
-    tf_publisher.publish_transform([1.0, 2.0, 3.0], [1.0, 0.0, 0.0, 0.0], timestamp)
+    def test_future_transform_wait(self) -> None:
+        if self.tf_listener is None or self.tf_publisher is None:
+            self.fail()
+        timestamp = self.tf_publisher.get_clock().now()
+        trans = Transform(translation=Vector3(x=1.0, y=2.0, z=3.0), rotation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))
+        self.tf_publisher.publish_transform(trans, timestamp)
 
-    rclpy.spin_once(tf_publisher, timeout_sec=0.01)
+        delay = 1
 
-    trans = tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp).transform
-    assert trans.translation.x == 1.0
-    assert trans.translation.y == 2.0
-    assert trans.translation.z == 3.0
+        def _delayed_publish() -> None:
+            if self.tf_publisher is None:
+                self.fail()
+            time.sleep(delay + 0.001)
+            delayed_timestamp = self.tf_publisher.get_clock().now()
+            self.tf_publisher.publish_transform(trans, delayed_timestamp)
 
-    assert trans.rotation.w == 1.0
-    assert trans.rotation.x == 0.0
-    assert trans.rotation.y == 0.0
-    assert trans.rotation.z == 0.0
-    print("Correct Transform Found")
+        thread = Thread(target=_delayed_publish)
+        thread.start()
 
-    # A future transform request with no timeout returns ExtrapolationException
-    print()
-    print("Looking up future transform without wait")
-    rclpy.spin_once(tf_publisher, timeout_sec=0.01)
-
-    lookup_err = None
-    try:
-        asyncio.run(
-            delayed_lookup(tf_publisher, tf_listener, [4.0, 5.0, 6.0], [0.0, 1.0, 0.0, 0.0], delay_sec=2, timeout=0)
-        )
-    except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException) as err:
-        lookup_err = err
-    assert isinstance(lookup_err, tf2_ros.ExtrapolationException)
-    print("ExtrapolationException Thrown")
-
-    # A future transform request with an insufficent timeout returns ExtrapolationException
-    print()
-    print("Looking up future transform with insufficient wait")
-    rclpy.spin_once(tf_publisher, timeout_sec=0.01)
-
-    lookup_err = None
-    try:
-        asyncio.run(
-            delayed_lookup(tf_publisher, tf_listener, [7.0, 8.0, 9.0], [0.0, 0.0, 1.0, 0.0], delay_sec=2, timeout=1)
-        )
-    except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException) as err:
-        lookup_err = err
-    assert isinstance(lookup_err, tf2_ros.ExtrapolationException)
-    print("ExtrapolationException Thrown")
-
-    # A future transform request with sufficient timeout returns correctly
-    print()
-    print("Looking up future transform with sufficient wait")
-    rclpy.spin_once(tf_publisher, timeout_sec=0.01)
-
-    asyncio.run(
-        delayed_lookup(tf_publisher, tf_listener, [10.0, 11.0, 12.0], [0.0, 0.0, 0.0, 1.0], delay_sec=2, timeout=4)
-    )
-    print("Correct Transform Found")
-
-    print("TFListenerWrapper Tests Complete")
-
-
-def test_tf_listener_wrapper_wait(tf_listener: TFListenerWrapper) -> None:
-    tf_publisher = MockTFPublisher(FRAME_ID, CHILD_FRAME_ID)
-
-    rclpy.spin_once(tf_publisher, timeout_sec=0.01)
-
-    asyncio.run(
-        delayed_lookup(tf_publisher, tf_listener, [4.0, 5.0, 6.0], [0.0, 1.0, 0.0, 0.0], delay_sec=2, check_init=True)
-    )
-
-    print("Successfully initialized TF")
-
-
-def main() -> None:
-    tf_listener = TFListenerWrapper()
-    test_tf_listener_wrapper(tf_listener)
+        timestamp += Duration(seconds=delay)
+        t = self.tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp, wait_for_frames=True, timeout=2)
+        self.assertTrue(equal_transform(t.transform, trans))
+        thread.join()
 
 
 if __name__ == "__main__":
-    main()
+    unittest.main()


### PR DESCRIPTION
This PR precedes the spatial math PR.

- Added an option to run a spin thread in the NodeWrapper - this was a design pattern that we were repeating in several places, so hopefully we can use this to reduce the duplicate code. It is set to behave the same as previously by default but has parameters to turn on the new functionality.
- Updated the `TFListenerWrapper` to have a context parameter (Used in unit tests, so we don't get an error from repeated init/shutdown of rclpy)
- Updated the unit test for `TFListenerWrapper` to be multiple tests instead of one lone test function (makes it easier to determine where the test is failing)
- Updated `TFListenerWrapper` to use the new NodeWrapper as it was employing the spin thread pattern
- Updates to the ServiceWrapper were just to make it line up with the changes to NodeWrapper and no changes to its interface
- Also, updated the copyrights to the new format we are using

- [x] I ran HIL tests on spot