### PR TITLE
[N/A] Added dockerfile and workflow to build it. Also, added codeowners for visibility

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,50 @@
+FROM ros:humble-ros-base-jammy
+
+SHELL ["/bin/bash", "-c"]
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# install packages
+RUN apt-get update \
+    && apt-get install -q -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG ROS_DISTRO=humble
+ENV ROS_DISTRO $ROS_DISTRO
+ARG INSTALL_PACKAGE=base
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
+    apt-get update -q && \
+    apt-get install -yq --no-install-recommends \
+    python3-pip \
+    python-is-python3 \
+    python3-argcomplete \
+    python3-colcon-common-extensions \
+    python3-colcon-mixin \
+    python3-pytest-cov \
+    python3-rosdep \
+    libpython3-dev \
+    python3-vcstool && \
+    rm -rf /var/lib/apt/lists/*
+
+# I added this
+RUN source "/opt/ros/${ROS_DISTRO}/setup.bash"
+
+# Spot packages
+RUN apt-get update -q && \
+    apt-get install -y --no-install-recommends \
+    ros-${ROS_DISTRO}-action-tutorials-interfaces && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install packages inside the new environment
+RUN python -m pip install --no-cache-dir --upgrade pip==22.3.1 \
+    && pip install --root-user-action=ignore --no-cache-dir --default-timeout=900 \
+    numpy==1.24.1 \
+    pip cache purge
+
+# ROS doesn't recognize the docker shells as terminals so force colored output
+ENV RCUTILS_COLORIZED_OUTPUT=1

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners
+* @jbarry-bdai @amessing-bdai

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,65 @@
+name: Build and publish Jammy/Humble Docker image
+
+on:
+  pull_request:
+    paths:
+      - ".devcontainer/**"
+  push:
+    branches:
+      - main
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: bdaiinstitute/ros_utilties_jammy_humble
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          file: .devcontainer/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This repo is currently using the docker image from spot_ros2, which apparently doesn't have all the packages needed to unit test this one (per #12). This PR creates a docker image for this repo similar to the spot_ros2 one, but with the spot stuff taken out and the needed stuff added in. Also, codeowners file for visibility and for the future (when others are maintaining this repo)