### PR TITLE
[SW-411] Spot teleop is not working as expected

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
@@ -21,6 +21,7 @@ class ActionClientWrapper(rclpy.action.ActionClient):
         namespace: Optional[str] = None,
         context: Optional[Context] = None,
         num_executor_threads: int = 1,
+        timeout_sec: float = 10.0,
     ) -> None:
         """Constructor
 
@@ -51,7 +52,7 @@ class ActionClientWrapper(rclpy.action.ActionClient):
         self._node_wrapper.get_logger().info(
             f"Waiting for action server for {self._node.get_namespace()}/{action_name}"
         )
-        self.wait_for_server()
+        self.wait_for_server(timeout_sec)
         self._node_wrapper.get_logger().info("Found server")
 
     def send_goal_and_wait(

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
@@ -52,8 +52,11 @@ class ActionClientWrapper(rclpy.action.ActionClient):
         self._node_wrapper.get_logger().info(
             f"Waiting for action server for {self._node.get_namespace()}/{action_name}"
         )
-        self.wait_for_server(timeout_sec)
-        self._node_wrapper.get_logger().info("Found server")
+        found_server = self.wait_for_server(timeout_sec)
+        if found_server:
+            self._node_wrapper.get_logger().info("Found server")
+        else:
+            self._node_wrapper.get_logger().warn(f"{self._node.get_namespace()}/{action_name} server not found")
 
     def send_goal_and_wait(
         self, action_name: str, goal: Action.Goal, timeout_sec: Optional[float] = None


### PR DESCRIPTION
The Spot teleop exposed a slight bug where the robot doesn't time out when it initializes a server that isn't present. This was the error on armless Spots like Fausto. With Gosu, I suspect there's a bigger issue because the Spot Cam payload is causing the driver to fail with this message:
![image](https://github.com/bdaiinstitute/ros_utilities/assets/137220849/e4d74ea1-687a-4904-ae69-b137595b675b)
