### PR TITLE
Enable safe synchronous programming in `rclpy`

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
@@ -3,6 +3,10 @@ from typing import Callable, Optional, Type, Union
 
 import rclpy.action
 from rclpy import Context
+from rclpy.node import Node
+from rclpy.action import ActionServer
+from rclpy.callback_groups import CallbackGroup
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 
 from bdai_ros2_wrappers.action_handle import ActionHandle
 from bdai_ros2_wrappers.node import NodeWrapper
@@ -136,3 +140,15 @@ class ActionClientWrapper(rclpy.action.ActionClient):
         handle.set_send_goal_future(send_goal_future)
 
         return handle
+
+
+class FriendlyActionClient(rclpy.action.ActionClient):
+
+    def __init__(
+        self,
+        node: Node, *args,
+        callback_group: Optional[CallbackGroup] = None, **kwargs
+    ) -> None:
+        if getattr(node, 'enable_callback_isolation', False) and callback_group is None:
+            callback_group = MutuallyExclusiveCallbackGroup()
+        super().__init__(node, *args, callback_group=callback_group, **kwargs)

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/action_server.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/action_server.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+from typing import Optional
+
+from rclpy.node import Node
+from rclpy.action import ActionServer
+from rclpy.callback_groups import CallbackGroup
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+
+
+class FriendlyActionServer(ActionServer):
+
+    def __init__(
+        self,
+        node: Node, *args,
+        callback_group: Optional[CallbackGroup] = None, **kwargs
+    ) -> None:
+        if getattr(node, 'enable_callback_isolation', False) and callback_group is None:
+            callback_group = MutuallyExclusiveCallbackGroup()
+        super().__init__(node, *args, callback_group=callback_group, **kwargs)

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/executors.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/executors.py
@@ -1,0 +1,266 @@
+import collections
+import concurrent.futures
+import dataclasses
+import logging
+import os
+import queue
+import threading
+import typing
+import weakref
+
+import rclpy.executors
+
+
+class AutoScalingThreadPool(concurrent.futures.Executor):
+
+    @dataclasses.dataclass
+    class Work:
+        future: concurrent.futures.Future
+        fn: typing.Callable[..., typing.Any]
+        args: typing.Tuple[typing.Any, ...]
+        kwargs: typing.Dict[str, typing.Any]
+
+        def execute(self) -> None:
+            try:
+                self.future.set_result(
+                    self.fn(*self.args, **self.kwargs))
+            except Exception as e:
+                self.future.set_exception(e)
+
+        def cancel(self) -> None:
+            self.future.cancel()
+
+        def cancelled(self) -> bool:
+            return self.future.cancelled()
+
+        def when_done(
+            self,
+            callback: typing.Callable[['AutoScalingThreadPool.Work'], None]
+        ) -> None:
+            self.future.add_done_callback(lambda f: callback(self))
+
+    def __init__(
+        self, *,
+        min_workers: typing.Optional[int] = None,
+        max_workers: typing.Optional[int] = None,
+        submission_quota: typing.Optional[int] = None,
+        max_idle_time: typing.Optional[float] = None
+    ):
+        if min_workers is None:
+            min_workers = 0
+        if min_workers < 0:
+            raise ValueError('Mini')
+        self._min_workers = min_workers
+
+        if max_workers is None:
+            max_workers = 32 * (os.cpu_count() or 1)
+        if max_workers < min_workers:
+            raise ValueError('Maximum number of workers must be larger than or equal to the minimum number')
+        self._max_workers = max_workers
+
+        if max_idle_time is None:
+            max_idle_time = 60.0
+        if max_idle_time <= 0:
+            raise ValueError('Maximum idle time for workers must be a positive number')
+        self._max_idle_time = max_idle_time
+
+        if submission_quota is None:
+            submission_quota = max_workers
+        if submission_quota <= 0:
+            raise ValueError('Quotas for submission must be a positive number')
+        self._submission_quota = submission_quota
+
+        self._submit_lock = threading.Lock()
+        self._shutdown_lock = threading.Lock()
+
+        self._workers: typing.List[threading.Thread] = list()
+        runqueue: queue.SimpleQueue = queue.SimpleQueue()
+        self._runqueue = runqueue
+        self._weakref = weakref.ref(
+            self, lambda ref: runqueue.put(None))
+        self._waitqueues: typing.Dict[
+            typing.Callable[..., typing.Any],
+            collections.deque
+        ] = collections.defaultdict(collections.deque)
+        self._runlists: typing.Dict[
+            typing.Callable[..., typing.Any], set
+        ] = collections.defaultdict(set)
+        self._runslots = threading.Semaphore(0)
+
+    def _do_cleanup_after(self, work: 'AutoScalingThreadPool.Work') -> None:
+        with self._submit_lock:
+            self._runlists[work.fn].remove(work)
+            if self._waitqueues[work.fn]:
+                work = self._waitqueues[work.fn].popleft()
+                while work.cancelled() and self._waitqueues[work.fn]:
+                    work = self._waitqueues[work.fn].popleft()
+                if not work.cancelled():
+                    self._do_submit(work)  # actually submit work
+                    self._runlists[work.fn].add(work)
+                    work.when_done(self._do_cleanup_after)
+            if not self._runlists[work.fn]:
+                del self._runlists[work.fn]
+            if not self._waitqueues[work.fn]:
+                del self._waitqueues[work.fn]
+
+    @classmethod
+    def _do_work(cls, executor_weakref: weakref.ref) -> None:
+        logger = logging.getLogger(__name__)
+        try:
+            while True:
+                executor = executor_weakref()
+                if executor is None:
+                    break
+
+                runqueue, runslots, timeout = (
+                    executor._runqueue,
+                    executor._runslots,
+                    executor._max_idle_time)
+
+                if executor._shutdown:
+                    runqueue.put(None)
+                    break
+
+                del executor
+
+                runslots.release()
+                try:
+                    work = runqueue.get(
+                        block=True,
+                        timeout=timeout)
+                except queue.Empty:
+                    continue
+
+                if work is not None:
+                    work.execute()
+                    del work
+        except BaseException as e:
+            logger.error(f'Worker threw an exception: {e}')
+
+    def _do_submit(self, work: 'AutoScalingThreadPool.Work') -> None:
+        if not self._runslots.acquire(blocking=False):
+            self._workers = [
+                w for w in self._workers if w.is_alive()]
+            if self._max_workers > len(self._workers):
+                worker = threading.Thread(
+                    target=self._do_work,
+                    args=(self._weakref,),
+                    daemon=True)
+                self._workers.append(worker)
+        self._runqueue.put(work)
+
+    def submit(self, fn, /, *args, **kwargs) -> concurrent.futures.Future:
+        with self._submit_lock, self._shutdown_lock:
+            if self._shutdown:
+                raise RuntimeError()
+            future: concurrent.futures.Future = concurrent.futures.Future()
+            WorkT = AutoScalingThreadPool.Work
+            work = WorkT(future, fn, args, kwargs)
+            if self._submission_quota > len(self._runlists[work.fn]):
+                if self._waitqueues[work.fn]:  # prioritize pending work
+                    self._waitqueues[work.fn].append(work)
+                    work = self._waitqueues[work.fn].popleft()
+                    while work.cancelled() and self._waitqueues[work.fn]:
+                        work = self._waitqueues[work.fn].popleft()
+                    if not self._waitqueues[work.fn]:
+                        del self._waitqueues[work.fn]
+                if not work.cancelled():
+                    self._do_submit(work)  # actually submit work
+                    self._runlists[work.fn].add(work)
+                    work.when_done(self._do_cleanup_after)
+            else:
+                self._waitqueues[work.fn].append(work)
+            return future
+
+    def shutdown(
+        self,
+        wait: bool = True, *,
+        cancel_futures: bool = False
+    ) -> None:
+        with self._shutdown_lock:
+            self._shutdown = True
+
+        if cancel_futures:
+            with self._submit_lock:
+                for runlist in self._runlists.values():
+                    for work in runlist:
+                        work.cancel()
+                for waitqueue in self._waitqueues.values():
+                    for work in waitqueue:
+                        work.cancel()
+
+        self._runqueue.put(None)
+        if wait:
+            for worker in self._workers:
+                worker.join()
+
+
+class AutoScalingMultiThreadedExecutor(rclpy.executors.Executor):
+
+    class TaskInCallbackGroup:
+
+        def __init__(
+            self,
+            task: rclpy.task.Task,
+            callback_group: rclpy.callback_groups.CallbackGroup
+        ):
+            self.task = task
+            self.callback_group = callback_group
+
+        def __getattr__(self, name: str) -> typing.Any:
+            return getattr(self.task, name)
+
+        def __hash__(self) -> int:
+            return hash((self.task, self.callback_group))
+
+    def __init__(
+        self,
+        max_threads: typing.Optional[int] = None,
+        max_thread_idle_time: typing.Optional[float] = None,
+        max_threads_per_callback_group: typing.Optional[int] = None, *,
+        context: typing.Optional[rclpy.context.Context] = None
+    ) -> None:
+        super().__init__(context=context)
+        self._executor = AutoScalingThreadPool(
+            max_workers=max_threads,
+            max_idle_time=max_thread_idle_time,
+            submission_quota=max_threads_per_callback_group)
+        self._tasks: typing.List[
+            AutoScalingMultiThreadedExecutor.TaskInCallbackGroup
+        ] = []
+
+    def _do_spin_once(self, *args, **kwargs) -> None:
+        TaskInCallbackGroupT = \
+            AutoScalingMultiThreadedExecutor.TaskInCallbackGroup
+        try:
+            task, entity, node = \
+                self.wait_for_ready_callbacks(*args, **kwargs)
+        except rclpy.executors.ExternalShutdownException:
+            pass
+        except rclpy.executors.ShutdownException:
+            pass
+        except rclpy.executors.TimeoutException:
+            pass
+        except rclpy.executors.ConditionReachedException:
+            pass
+        else:
+            task = TaskInCallbackGroupT(
+                task, entity.callback_group)
+            self._executor.submit(task)
+            self._tasks.append(task)
+
+            for task in self._tasks[:]:
+                if task.done():
+                    self._tasks.remove(task)
+                    task.result()
+
+    def spin_once(self, timeout_sec: typing.Optional[float] = None) -> None:
+        self._do_spin_once(timeout_sec)
+
+    def spin_once_until_future_complete(
+        self,
+        future: rclpy.task.Future,
+        timeout_sec: typing.Optional[float] = None
+    ) -> None:
+        future.add_done_callback(lambda f: self.wake())
+        self._do_spin_once(timeout_sec, condition=future.done)

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/node.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/node.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from rclpy import Context, Future
 from rclpy.executors import ExternalShutdownException, MultiThreadedExecutor, ShutdownException, SingleThreadedExecutor
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.node import Node
 
 from bdai_ros2_wrappers.futures import wait_for_future
@@ -87,3 +88,50 @@ class NodeWrapper(Node):
     # def __del__(self) -> None:
     #     """Destructor"""
     #     self.shutdown()
+
+
+class FriendlyNode(Node):
+
+    def __init__(self, *args, enable_callback_isolation=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enable_callback_isolation = enable_callback_isolation
+
+    @property
+    def enable_callback_isolation(self) -> bool:
+        return self._enable_callback_isolation
+
+    def create_subscription(self, *args, callback_group = None, **kwargs):
+        if callback_group is None and self._enable_callback_isolation:
+            callback_group = MutuallyExclusiveCallbackGroup()
+        return super().create_subscription(
+            *args, callback_group=callback_group, **kwargs)
+
+    def create_publisher(self, *args, callback_group = None, **kwargs):
+        if callback_group is None and self._enable_callback_isolation:
+            callback_group = MutuallyExclusiveCallbackGroup()
+        return super().create_publisher(
+            *args, callback_group=callback_group, **kwargs)
+
+    def create_client(self, *args, callback_group = None, **kwargs):
+        if callback_group is None and self._enable_callback_isolation:
+            callback_group = MutuallyExclusiveCallbackGroup()
+        return super().create_client(
+            *args, callback_group=callback_group, **kwargs)
+
+    def create_service(self, *args, callback_group = None, **kwargs):
+        if callback_group is None and self._enable_callback_isolation:
+            callback_group = MutuallyExclusiveCallbackGroup()
+        return super().create_service(
+            *args, callback_group=callback_group, **kwargs)
+
+    def create_timer(self, *args, callback_group = None, **kwargs):
+        if callback_group is None and self._enable_callback_isolation:
+            callback_group = MutuallyExclusiveCallbackGroup()
+        return super().create_timer(
+            *args, callback_group=callback_group, **kwargs)
+
+    def create_guard_condition(self, *args, callback_group = None, **kwargs):
+        if callback_group is None and self._enable_callback_isolation:
+            callback_group = MutuallyExclusiveCallbackGroup()
+        return super().create_guard_condition(
+            *args, callback_group=callback_group, **kwargs)

--- a/bdai_ros2_wrappers/test/test_executors.py
+++ b/bdai_ros2_wrappers/test/test_executors.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+import pytest
+import threading
+
+import rclpy.task
+import std_srvs.srv
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+
+from bdai_ros2_wrappers.executors import AutoScalingThreadPool
+from bdai_ros2_wrappers.executors import AutoScalingMultiThreadedExecutor
+
+
+@pytest.fixture
+def pytest_context():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+    try:
+        yield context
+    finally:
+        context.try_shutdown()
+
+
+@pytest.fixture
+def pytest_node(pytest_context):
+    node = rclpy.create_node(
+        'pytest_node', context=pytest_context)
+    try:
+        yield node
+    finally:
+        node.destroy_node()
+
+
+def test_autoscaling_thread_pool():
+    """
+    Asserts that the autoscaling thread pool scales and de-scales on demand.
+    """
+
+    pool = AutoScalingThreadPool(max_idle_time=2)
+    assert len(pool.workers) == 0
+
+    events = [threading.Event() for _ in range(10)]
+    results = pool.map(lambda i, e: e.wait() and i, range(10), events)
+    assert len(pool.workers) == len(events)
+
+    for e in events:
+        e.set()
+    assert list(results) == list(range(10))
+
+    for worker in pool.workers:
+        worker.join(timeout=10)
+        assert not worker.is_alive()
+
+    assert len(pool.workers) == 0
+
+
+def test_autoscaling_executor(pytest_context, pytest_node):
+    """
+    Asserts that the autoscaling multithreaded executor scales to
+    attend a synchronous service call from a "one-shot" timer callback,
+    serviced by the same executor.
+    """
+    def dummy_server_callback(_, response):
+        response.success = True
+        return response
+
+    service = pytest_node.create_service(
+        std_srvs.srv.Trigger, '/dummy/trigger', dummy_server_callback,
+        callback_group=MutuallyExclusiveCallbackGroup())
+
+    client = pytest_node.create_client(
+        std_srvs.srv.Trigger, '/dummy/trigger',
+        callback_group=MutuallyExclusiveCallbackGroup())
+
+    future = rclpy.task.Future()
+
+    def deferred_dummy_trigger():
+        nonlocal timer
+        timer.cancel()
+        future.set_result(client.call(
+            std_srvs.srv.Trigger.Request()))
+
+    timer = pytest_node.create_timer(
+        0.5, deferred_dummy_trigger,
+        callback_group=MutuallyExclusiveCallbackGroup())
+
+    executor = AutoScalingMultiThreadedExecutor(context=pytest_context)
+    assert len(executor.thread_pool.workers) == 0
+    executor.add_node(pytest_node)
+    executor.spin_until_future_complete(future, timeout_sec=5)
+    executor.remove_node(pytest_node)
+    executor.shutdown()
+
+    response = future.result()
+    assert response.success


### PR DESCRIPTION
Precisely what the title says, based on a conversation with @jbarry-bdai. This PR introduces:

- a multi-threaded `rclpy.executors.Executor` implementation based on a thread pool that scales up and down based on usage, and
- `rclpy.node.Node`, `rclpy_action.client.ActionClient`, and `rclpy_action.server.ActionServer` subclasses to optionally isolate each callback in its own mutually exclusive callback group (effectively precluding concurrent invocations of the same callback)

which, in combination, enable safe synchronous programming across `rclpy` (ie. ROS 2) callbacks without risking a deadlock.
