### PR TITLE
Add logging to ROS 2 forwarding support

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/logging.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/logging.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+
+import contextlib
+import logging
+import typing
+
+import rclpy.logging
+
+# NOTE(hidmic): tinkering with implementation details is not ideal,
+# but there is not a lot of room for alternatives. This inconvenience
+# will go away when and if this module is contributed upstream.
+from rclpy.impl.implementation_singleton import rclpy_implementation as impl
+from rclpy.node import Node
+
+SEVERITY_MAP = {
+    logging.NOTSET: rclpy.logging.LoggingSeverity.UNSET,
+    logging.DEBUG: rclpy.logging.LoggingSeverity.DEBUG,
+    logging.INFO: rclpy.logging.LoggingSeverity.INFO,
+    logging.WARN: rclpy.logging.LoggingSeverity.WARN,
+    logging.ERROR: rclpy.logging.LoggingSeverity.ERROR,
+    logging.CRITICAL: rclpy.logging.LoggingSeverity.FATAL,
+}
+
+
+class RcutilsLogHandler(logging.Handler):
+    """A `logging.Handler` subclass to forward log records to the ROS 2 logging system."""
+
+    default_formatter = logging.Formatter("(logging.%(name)s) %(message)s")
+
+    def __init__(self, node: Node, level: typing.Union[int, str] = logging.NOTSET) -> None:
+        super().__init__(level=level)
+        self.node = node
+        self.logger = node.get_logger()
+        if self.level != logging.NOTSET:
+            self.logger.set_level(SEVERITY_MAP[self.level])
+        self.setFormatter(self.default_formatter)
+
+    def setLevel(self, level: typing.Union[int, str]) -> None:
+        super().setLevel(level)
+        self.logger.set_level(SEVERITY_MAP[self.level])
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            message = self.format(record)
+            severity = SEVERITY_MAP[record.levelno]
+            # NOTE(hidmic): this bypasses the rclpy logger API
+            # to avoid the extra meaningless computations (e.g.
+            # call stack inspection).
+            #
+            # TODO(hidmic): use subloggers when migrating to Iron
+            # (or the feature is backported to Humble).
+            impl.rclpy_logging_rcutils_log(
+                severity, self.logger.name, message, record.funcName, record.pathname, record.lineno
+            )
+        except Exception:
+            self.handleError(record)
+
+
+@contextlib.contextmanager
+def logs_to_ros(node: Node) -> typing.Iterator[None]:
+    """
+    Forwards root `logging.Logger` logs to the ROS 2 logging system.
+
+    :param node: a ROS 2 node, necessary for rosout logging (if enabled).
+    """
+    root = logging.getLogger()
+    handler = RcutilsLogHandler(node)
+    root.addHandler(handler)
+    try:
+        yield
+    finally:
+        root.removeHandler(handler)

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/logging.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/logging.py
@@ -22,6 +22,21 @@ SEVERITY_MAP = {
 }
 
 
+if not typing.TYPE_CHECKING:
+    import os.path
+    import warnings
+    import xml.etree.ElementTree as ET
+
+    import ament_index_python
+    import packaging.version
+
+    share_directory = ament_index_python.get_package_share_directory("rclpy")
+    tree = ET.parse(os.path.join(share_directory, "package.xml"))
+    version = tree.getroot().find("version")
+    if packaging.version.parse(version.text) >= packaging.version.parse("3.9.0"):
+        warnings.warn("TODO: use subloggers in RcutilsLogHandler implementation")
+
+
 class RcutilsLogHandler(logging.Handler):
     """A `logging.Handler` subclass to forward log records to the ROS 2 logging system."""
 
@@ -43,12 +58,8 @@ class RcutilsLogHandler(logging.Handler):
         try:
             message = self.format(record)
             severity = SEVERITY_MAP[record.levelno]
-            # NOTE(hidmic): this bypasses the rclpy logger API
-            # to avoid the extra meaningless computations (e.g.
-            # call stack inspection).
-            #
-            # TODO(hidmic): use subloggers when migrating to Iron
-            # (or the feature is backported to Humble).
+            # NOTE(hidmic): this bypasses the rclpy logger API to avoid the extra meaningless
+            # computations (e.g. call stack inspection).
             impl.rclpy_logging_rcutils_log(
                 severity, self.logger.name, message, record.funcName, record.pathname, record.lineno
             )

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/logging.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/logging.py
@@ -61,7 +61,18 @@ def logs_to_ros(node: Node) -> typing.Iterator[None]:
     """
     Forwards root `logging.Logger` logs to the ROS 2 logging system.
 
-    :param node: a ROS 2 node, necessary for rosout logging (if enabled).
+    Note that logs are subject to severity level thresholds and propagation
+    semantics at both the `logging` module and the ROS 2 logging system. For
+    instance, for an informational log made from a non-root `logging` logger
+    to find its way to a ROS 2 logging system sink like the `/rosout` topic:
+
+    - the entire `logging` hierarchy all the way up to the root logger, and the
+      ROS 2 node logger must be configured with a severity level at or below
+      INFO;
+    - and the `logging` hierarchy must be configured to propagate logs (true by default).
+
+    Args:
+        node: a ROS 2 node, necessary for rosout logging (if enabled).
     """
     root = logging.getLogger()
     handler = RcutilsLogHandler(node)

--- a/bdai_ros2_wrappers/examples/logs_to_ros_example.py
+++ b/bdai_ros2_wrappers/examples/logs_to_ros_example.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+
+"""
+An example of `logging` logs forward to the ROS 2 logging system.
+
+Run with:
+
+```sh
+python3 examples/logs_to_ros_example.py
+```
+"""
+
+import itertools
+import logging
+
+import rclpy
+
+from bdai_ros2_wrappers.logging import logs_to_ros
+
+
+def main() -> None:
+    rclpy.init()
+    try:
+        node = rclpy.create_node("example_logger")
+        counter = itertools.count(start=1)
+
+        def callback() -> None:
+            logging.info("Called back %d times", next(counter))
+
+        node.create_timer(1, callback)
+        with logs_to_ros(node):
+            rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        rclpy.try_shutdown()
+
+
+if __name__ == "__main__":
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    main()

--- a/bdai_ros2_wrappers/test/test_logging.py
+++ b/bdai_ros2_wrappers/test/test_logging.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+import logging
+from typing import Generator, Optional
+
+import pytest
+import rclpy
+from rcl_interfaces.msg import Log
+from rclpy.context import Context
+from rclpy.executors import Executor, SingleThreadedExecutor
+from rclpy.node import Node
+from rclpy.task import Future
+
+from bdai_ros2_wrappers.logging import logs_to_ros
+
+
+@pytest.fixture(autouse=True)
+def ros_context() -> Generator[Context, None, None]:
+    context = Context()
+    args = ["--ros-args", "--enable-rosout-logs"]
+    rclpy.init(context=context, args=args)
+    try:
+        yield context
+    finally:
+        context.try_shutdown()
+
+
+@pytest.fixture
+def ros_node(ros_context: Context) -> Generator[Node, None, None]:
+    node = rclpy.create_node("test_node", context=ros_context)
+    try:
+        yield node
+    finally:
+        node.destroy_node()
+
+
+@pytest.fixture
+def ros_executor(ros_context: Context, ros_node: Node) -> Generator[Executor, None, None]:
+    executor = SingleThreadedExecutor(context=ros_context)
+    executor.add_node(ros_node)
+    try:
+        yield executor
+    finally:
+        executor.remove_node(ros_node)
+        executor.shutdown()
+
+
+def test_log_forwarding(ros_node: Node, ros_executor: Executor) -> None:
+    future: Optional[Future] = None
+
+    def callback(message: Log) -> None:
+        nonlocal future
+        if future and not future.done():
+            future.set_result(message)
+
+    ros_node.create_subscription(Log, "/rosout", callback, 10)
+
+    future = Future()
+    with logs_to_ros(ros_node):
+        logger = logging.getLogger("my_logger")
+        logger.propagate = True  # ensure propagation is enabled
+        logger.info("test")
+
+    ros_executor.spin_until_future_complete(future, timeout_sec=10)
+    assert future.done()
+    log = future.result()
+    # NOTE(hidmic) why are log levels of bytestring type !?
+    assert log.level == int.from_bytes(Log.INFO, byteorder="little")
+    assert log.name == ros_node.get_logger().name
+    assert log.msg == "(logging.my_logger) test"


### PR DESCRIPTION
A first POC of how we could forward `logging` logs through the ROS 2 logging system (actually `rclpy`'s -> `rcl`'s -> `rcutils`').