### PR TITLE
[PN-64] Add ROSBag_Recorder Utility

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/rosbag_recorder.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/rosbag_recorder.py
@@ -1,16 +1,19 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
 import threading
+from pathlib import Path
 
 import rclpy
+from rclpy.impl import rcutils_logger
 from rosbag2_py import Recorder, RecordOptions, StorageOptions
 
 
 class ROSBagRecorder(object):
     def __init__(
         self,
-        bag_file_path: str,
+        bag_file_path: Path,
         storage_id: str = "sqlite3",
     ) -> None:
+        self._logger = rcutils_logger.RcutilsLogger(name="rosbag_recorder")
         self._rosbag_recorder = Recorder()
 
         self._record_options = RecordOptions()
@@ -18,21 +21,26 @@ class ROSBagRecorder(object):
 
         self._bag_path = bag_file_path
 
-        self._storage_options = StorageOptions(uri=self._bag_path, storage_id=storage_id)
+        self._storage_options = StorageOptions(uri=str(self._bag_path), storage_id=storage_id)
 
         self._thread = threading.Thread(target=self._record)
 
     @property
-    def bag_path(self) -> str:
+    def bag_path(self) -> Path:
         return self._bag_path
 
     def start(self) -> None:
+        self._logger.debug("Starting Rosbag recorder thread")
         self._thread.start()
 
     def stop(self) -> None:
+        self._logger.debug("Stopping Rosbag recorder")
         self._rosbag_recorder.cancel()
         self._thread.join()
 
     def _record(self) -> None:
+        if self._bag_path.exists():
+            self._logger.error("Cannot overwrite rosbag that already exists.")
+            return
         if rclpy.ok():
             self._rosbag_recorder.record(self._storage_options, self._record_options)

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/rosbag_recorder.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/rosbag_recorder.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+from typing import Optional
+from datetime import datetime
+
+from rosbag2_py import Recorder, RecordOptions, StorageOptions
+from bdai.utilities.path import get_bdai_path
+import os
+from rclpy.node import Node
+import threading
+import rclpy
+
+
+ROS_BAG_NAME_TIMESTAMP_FORMAT: str = "rosbag2_%Y_%m_%d-%H_%M_%S_%f"
+
+class ROSBagRecorder(object):
+    def __init__(
+        self,
+        bag_file_name: str,
+        bag_file_dir: Optional[str] = None,
+        storage_id: str = "sqlite3",
+    ) -> None:
+        self._rosbag_recorder = Recorder()
+
+        self._record_options = RecordOptions()
+        self._record_options.all = True
+
+        bag_file_name += "_"
+
+        self._node_name = bag_file_name + "recorder"
+
+        dt = datetime.now().strftime(ROS_BAG_NAME_TIMESTAMP_FORMAT)
+        bag_name = "{}{}".format(bag_file_name, dt)
+        if bag_file_dir:
+            self._bag_path = os.path.join(bag_file_dir, bag_name)
+        else:
+            self._bag_path = os.path.join(get_bdai_path(), "recordings", bag_name)
+
+        self._storage_options = StorageOptions(
+            uri=self._bag_path,
+            storage_id=storage_id)
+
+    @property
+    def bag_path(self) -> str:
+        return self._bag_path
+
+    def start_recording(self) -> None:
+        if rclpy.ok():
+            self._rosbag_recorder.record(self._storage_options, self._record_options)
+
+    def stop_recording(self) -> None:
+        self._rosbag_recorder.cancel()

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/rosbag_recorder.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/rosbag_recorder.py
@@ -2,10 +2,8 @@
 import os
 import threading
 from datetime import datetime
-from typing import Optional
 
 import rclpy
-from bdai.utilities.path import get_bdai_path
 from rosbag2_py import Recorder, RecordOptions, StorageOptions
 
 ROS_BAG_NAME_TIMESTAMP_FORMAT: str = "rosbag2_%Y_%m_%d-%H_%M_%S_%f"
@@ -14,8 +12,7 @@ ROS_BAG_NAME_TIMESTAMP_FORMAT: str = "rosbag2_%Y_%m_%d-%H_%M_%S_%f"
 class ROSBagRecorder(object):
     def __init__(
         self,
-        bag_file_name: str,
-        bag_file_dir: Optional[str] = None,
+        bag_file_path: str,
         storage_id: str = "sqlite3",
     ) -> None:
         self._rosbag_recorder = Recorder()
@@ -23,16 +20,7 @@ class ROSBagRecorder(object):
         self._record_options = RecordOptions()
         self._record_options.all = True
 
-        bag_file_name += "_"
-
-        self._node_name = bag_file_name + "recorder"
-
-        dt = datetime.now().strftime(ROS_BAG_NAME_TIMESTAMP_FORMAT)
-        bag_name = "{}{}".format(bag_file_name, dt)
-        if bag_file_dir:
-            self._bag_path = os.path.join(bag_file_dir, bag_name)
-        else:
-            self._bag_path = os.path.join(get_bdai_path(), "recordings", bag_name)
+        self._bag_path = "{}_{}".format(bag_file_path, datetime.now().strftime(ROS_BAG_NAME_TIMESTAMP_FORMAT))
 
         self._storage_options = StorageOptions(uri=self._bag_path, storage_id=storage_id)
 

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/rosbag_recorder.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/rosbag_recorder.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
-import os
 import threading
 from datetime import datetime
 

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/rosbag_recorder.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/rosbag_recorder.py
@@ -1,11 +1,8 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
 import threading
-from datetime import datetime
 
 import rclpy
 from rosbag2_py import Recorder, RecordOptions, StorageOptions
-
-ROS_BAG_NAME_TIMESTAMP_FORMAT: str = "rosbag2_%Y_%m_%d-%H_%M_%S_%f"
 
 
 class ROSBagRecorder(object):
@@ -19,7 +16,7 @@ class ROSBagRecorder(object):
         self._record_options = RecordOptions()
         self._record_options.all = True
 
-        self._bag_path = "{}_{}".format(bag_file_path, datetime.now().strftime(ROS_BAG_NAME_TIMESTAMP_FORMAT))
+        self._bag_path = bag_file_path
 
         self._storage_options = StorageOptions(uri=self._bag_path, storage_id=storage_id)
 

--- a/bdai_ros2_wrappers/test/test_rosbag_recorder.py
+++ b/bdai_ros2_wrappers/test/test_rosbag_recorder.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+import os
+import unittest
+from typing import Optional
+
+import rclpy
+from rclpy.node import Node
+from rclpy import Context
+
+from bdai_ros2_wrappers.rosbag_recorder import ROSBagRecorder
+from rclpy.executors import MultiThreadedExecutor
+from std_msgs.msg import String
+
+BAG_FILE_DIR = os.path.join(os.getenv("BDAI", "/workspaces/bdai"), "recording")
+BAG_FILE_NAME = "unit_test_ros2_bag"
+
+
+class MinimalPublisher(Node):
+    def __init__(self) -> None:
+        super().__init__('minimal_publisher')
+        self.publisher_ = self.create_publisher(String, 'topic', 10)
+        timer_period = 0.5  # seconds
+        self.timer = self.create_timer(timer_period, self.timer_callback)
+        self.i = 0
+
+    def timer_callback(self) -> None:
+        msg = String()
+        msg.data = 'Hello World: %d' % self.i
+        self.publisher_.publish(msg)
+        self.get_logger().info('Publishing: "%s"' % msg.data)
+        self.i += 1
+
+
+class ROSBagRecorderTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.context: Optional[Context] = Context()
+        rclpy.init(context=self.context)
+        self.rosbag_recorder = ROSBagRecorder(bag_file_name=BAG_FILE_NAME, bag_file_dir=BAG_FILE_DIR)
+        self.minimal_pub = MinimalPublisher()
+
+        self.rosbag_recorder.start()
+        rclpy.spin(self.minimal_pub)
+
+    def tearDown(self) -> None:
+        self.rosbag_recorder.stop()
+        self.minimal_pub.destroy_node()
+        rclpy.shutdown(context=self.context)
+        self.context = None
+
+    def test_bag_creation(self) -> None:
+        """
+        Tests normal operation of recording a minimal publisher, ensure rosbag is generated
+        """
+        expected_bag_file_path = os.path.join(BAG_FILE_DIR, BAG_FILE_NAME)
+        self.assertEqual(expected_bag_file_path, self.rosbag_recorder.bag_path)
+        self.assertTrue(os.path.exists(self.rosbag_recorder.bag_path))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bdai_ros2_wrappers/test/test_rosbag_recorder.py
+++ b/bdai_ros2_wrappers/test/test_rosbag_recorder.py
@@ -34,7 +34,7 @@ class ROSBagRecorderTest(unittest.TestCase):
     def setUp(self) -> None:
         self.context: Optional[Context] = Context()
         rclpy.init(context=self.context)
-        self.rosbag_recorder = ROSBagRecorder(bag_file_name=BAG_FILE_NAME, bag_file_dir=BAG_FILE_DIR)
+        self.rosbag_recorder = ROSBagRecorder(os.path.join(BAG_FILE_NAME, BAG_FILE_DIR))
         self.minimal_pub = MinimalPublisher()
 
         self.rosbag_recorder.start()

--- a/bdai_ros2_wrappers/test/test_rosbag_recorder.py
+++ b/bdai_ros2_wrappers/test/test_rosbag_recorder.py
@@ -4,12 +4,11 @@ import unittest
 from typing import Optional
 
 import rclpy
-from rclpy.node import Node
 from rclpy import Context
+from rclpy.node import Node
+from std_msgs.msg import String
 
 from bdai_ros2_wrappers.rosbag_recorder import ROSBagRecorder
-from rclpy.executors import MultiThreadedExecutor
-from std_msgs.msg import String
 
 BAG_FILE_DIR = os.path.join(os.getenv("BDAI", "/workspaces/bdai"), "recording")
 BAG_FILE_NAME = "unit_test_ros2_bag"
@@ -17,15 +16,15 @@ BAG_FILE_NAME = "unit_test_ros2_bag"
 
 class MinimalPublisher(Node):
     def __init__(self) -> None:
-        super().__init__('minimal_publisher')
-        self.publisher_ = self.create_publisher(String, 'topic', 10)
+        super().__init__("minimal_publisher")
+        self.publisher_ = self.create_publisher(String, "topic", 10)
         timer_period = 0.5  # seconds
         self.timer = self.create_timer(timer_period, self.timer_callback)
         self.i = 0
 
     def timer_callback(self) -> None:
         msg = String()
-        msg.data = 'Hello World: %d' % self.i
+        msg.data = "Hello World: %d" % self.i
         self.publisher_.publish(msg)
         self.get_logger().info('Publishing: "%s"' % msg.data)
         self.i += 1
@@ -54,6 +53,7 @@ class ROSBagRecorderTest(unittest.TestCase):
         expected_bag_file_path = os.path.join(BAG_FILE_DIR, BAG_FILE_NAME)
         self.assertEqual(expected_bag_file_path, self.rosbag_recorder.bag_path)
         self.assertTrue(os.path.exists(self.rosbag_recorder.bag_path))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/bdai_ros2_wrappers/test/test_rosbag_recorder.py
+++ b/bdai_ros2_wrappers/test/test_rosbag_recorder.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
-import os
 import unittest
+from pathlib import Path
 
 import rclpy
 from rclpy.node import Node
@@ -8,7 +8,7 @@ from std_msgs.msg import String
 
 from bdai_ros2_wrappers.rosbag_recorder import ROSBagRecorder
 
-BAG_FILE_DIR = os.path.join(os.getenv("BDAI", "/workspaces/bdai"), "recording")
+BAG_FILE_DIR = Path.home() / "recordings"
 BAG_FILE_NAME = "unit_test_ros2_bag"
 PUBLISH_COUNT = 20
 
@@ -36,7 +36,7 @@ class ROSBagRecorderTest(unittest.TestCase):
     def setUp(self) -> None:
         rclpy.init()
 
-        self.rosbag_recorder = ROSBagRecorder(os.path.join(BAG_FILE_DIR, BAG_FILE_NAME))
+        self.rosbag_recorder = ROSBagRecorder(Path(BAG_FILE_DIR, BAG_FILE_NAME))
         self.minimal_pub = MinimalPublisher()
 
         try:
@@ -54,9 +54,9 @@ class ROSBagRecorderTest(unittest.TestCase):
         """
         Tests normal operation of recording a minimal publisher, ensure rosbag is generated
         """
-        expected_bag_file_path = os.path.join(BAG_FILE_DIR, BAG_FILE_NAME)
+        expected_bag_file_path = Path(BAG_FILE_DIR, BAG_FILE_NAME)
         self.assertEqual(expected_bag_file_path, self.rosbag_recorder.bag_path)
-        self.assertTrue(os.path.exists(self.rosbag_recorder.bag_path))
+        self.assertTrue(self.rosbag_recorder.bag_path.exists())
 
 
 if __name__ == "__main__":

--- a/bdai_ros2_wrappers/test/test_rosbag_recorder.py
+++ b/bdai_ros2_wrappers/test/test_rosbag_recorder.py
@@ -1,10 +1,8 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
 import os
 import unittest
-from typing import Optional
 
 import rclpy
-from rclpy import Context
 from rclpy.node import Node
 from std_msgs.msg import String
 
@@ -31,7 +29,6 @@ class MinimalPublisher(Node):
 
 
 class ROSBagRecorderTest(unittest.TestCase):
-
     def setUp(self) -> None:
         rclpy.init()
 
@@ -44,8 +41,7 @@ class ROSBagRecorderTest(unittest.TestCase):
     def tearDown(self) -> None:
         self.rosbag_recorder.stop()
         self.minimal_pub.destroy_node()
-        rclpy.shutdown(context=self.context)
-        self.context = None
+        rclpy.shutdown()
 
     def test_bag_creation(self) -> None:
         """

--- a/bdai_ros2_wrappers/test/test_rosbag_recorder.py
+++ b/bdai_ros2_wrappers/test/test_rosbag_recorder.py
@@ -31,9 +31,10 @@ class MinimalPublisher(Node):
 
 
 class ROSBagRecorderTest(unittest.TestCase):
+
     def setUp(self) -> None:
-        self.context: Optional[Context] = Context()
-        rclpy.init(context=self.context)
+        rclpy.init()
+
         self.rosbag_recorder = ROSBagRecorder(os.path.join(BAG_FILE_NAME, BAG_FILE_DIR))
         self.minimal_pub = MinimalPublisher()
 


### PR DESCRIPTION
Adds a wrapper around `ros2bag::record` to simplify recording rosbags when creating python nodes

This will be followed up by a PR to `bdai` that will update/add examples on how to use the utility with the walk forward example

In order to test, refer to the [`example_walk_forward_with_recording.py`](https://github.com/bdaiinstitute/bdai/blob/ffaa88b5f2c5edb611f441a002b7f794da7f779d/ws/src/spot_utilities/examples/example_walk_forward_with_recording.py) from [this PR to bdai](https://github.com/bdaiinstitute/bdai/pull/921)