### PR TITLE
Push ROS 2 to the background

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/process.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/process.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+import functools
+import inspect
+import pathlib
+import sys
+import threading
+import typing
+
+import rclpy
+import rclpy.executors
+import rclpy.node
+
+from bdai_ros2_wrappers.executors import AutoScalingMultiThreadedExecutor
+from bdai_ros2_wrappers.node import Node
+
+
+class ROSAwareScope(typing.ContextManager["ROSAwareScope"]):
+    """
+    A context manager to enable ROS code in a given scope by providing
+    an `rclpy` node and an autoscaling multi-threaded executor spinning
+    in a background thread.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        context: typing.Optional[rclpy.context.Context] = None,
+        node_args: typing.Optional[typing.Dict[str, typing.Any]] = None,
+        executor_args: typing.Optional[typing.Dict[str, typing.Any]] = None,
+    ):
+        """
+        Initializes the ROS aware scope.
+
+        Args:
+            name: name for this scope, and for the underlying node.
+            context: optional context for the underlying node.
+            node_args: optional keyword arguments for the underlying node.
+            executor_args: optional keyword arguments for the underlying executor.
+        """
+        self._name = name
+        self._context = context
+        self._node: typing.Optional[rclpy.node.Node] = None
+        self._node_args: typing.Dict[str, typing.Any] = node_args or {}
+        self._executor: typing.Optional[rclpy.executors.Executor] = None
+        self._executor_args: typing.Dict[str, typing.Any] = executor_args or {}
+        self._background_thread: typing.Optional[threading.Thread] = None
+        self._active = False
+
+    def __enter__(self) -> "ROSAwareScope":
+        """
+        Activates scope.
+
+        An active scope cannot be re-entered.
+        """
+        if self._active:
+            raise RuntimeError("cannot enter active scope")
+        self._node = Node(self._name, context=self._context, **self._node_args)
+        try:
+            self._executor = AutoScalingMultiThreadedExecutor(
+                context=self._context, logger=self._node.get_logger(), **self._executor_args
+            )
+            self._background_thread = threading.Thread(target=self._executor.spin)
+            try:
+                self._executor.add_node(self._node)
+                self._background_thread.start()
+            except:
+                self._executor.shutdown()
+                self._executor = None
+                self._background_thread = None
+                raise
+            self._active = True
+            return self
+        except:
+            self._node.destroy_node()
+            self._node = None
+            raise
+
+    def __exit__(self, *exc: typing.Any) -> None:
+        """
+        Deactivates scope.
+
+        An inactive scope cannot be deactivated.
+        """
+        if not self._active:
+            raise RuntimeError("cannot exit inactive scope")
+        assert self._executor is not None
+        assert self._background_thread is not None
+        assert self._node is not None
+        self._executor.shutdown()
+        self._executor = None
+        self._background_thread.join()
+        self._background_thread = None
+        self._node.destroy_node()
+        self._node = None
+        self._active = False
+
+    @property
+    def node(self) -> rclpy.node.Node:
+        """Scope node, if active."""
+        if not self._active:
+            raise RuntimeError("scope is not active")
+        assert self._node is not None
+        return self._node
+
+    @property
+    def executor(self) -> rclpy.executors.Executor:
+        """Scope executor, if active."""
+        if not self._active:
+            raise RuntimeError("scope is not active")
+        assert self._executor is not None
+        return self._executor
+
+
+MainCallableWithArgs = typing.Callable[[typing.Optional[typing.Sequence[str]]], typing.Optional[int]]
+MainCallableWithNoArgs = typing.Callable[[], typing.Optional[int]]
+MainCallable = typing.Union[MainCallableWithNoArgs, MainCallableWithArgs]
+
+
+class ROSAwareProcess:
+    """
+    A ``main``-like function wrapper that binds a ROS aware scope to each function invocation.
+
+    Only one process can be invoked at a time, becoming the ``current`` process.
+    This enables global access to the process and, in consequence, to its scope.
+
+    This wrapper will rarely be used explicitly but through the `wrap` decorator.
+    """
+
+    lock = threading.Lock()
+
+    current: typing.Optional["ROSAwareProcess"] = None
+
+    def __init__(self, func: MainCallable, name: typing.Optional[str] = None, **kwargs: typing.Any):
+        """
+        Initializes the ROS aware process.
+
+        Args:
+            func: a ``main``-like function to wrap.
+            name: an optional name for this process and the underlying node.
+            If not provided, the basename without extension of the calling executable will be used.
+
+        Additional keyword arguments will be forwarded to the process' `ROSAwareScope` instance.
+        """
+        self._func = func
+        if name is None:
+            name = pathlib.Path(sys.argv[0]).stem
+        self._name = name
+        self._kwargs = kwargs
+        self._scope: typing.Optional[ROSAwareScope] = None
+        functools.update_wrapper(self, self._func)
+
+    def __getattr__(self, name: str) -> typing.Any:
+        """Gets attribute from scope, if any."""
+        if self._scope is None:
+            return super().__getattribute__(name)
+        return getattr(self._scope, name)
+
+    def __call__(self, args: typing.Optional[typing.Sequence[str]] = None) -> typing.Optional[int]:
+        """
+        Invokes wrapped function in a ROS aware scope.
+
+        Args:
+            args: optional command line-like arguments.
+
+        Returns:
+            an optional return code.
+
+        Raises:
+            RuntimeError: if a ROS aware process is already running.
+        """
+        if not ROSAwareProcess.lock.acquire(blocking=False):
+            raise RuntimeError("Process already running!")
+        try:
+            rclpy.init(args=args)
+            try:
+                with ROSAwareScope(self._name, **self._kwargs) as scope:
+                    self._scope = scope
+                    ROSAwareProcess.current = self
+                    try:
+                        sig = inspect.signature(self._func)
+                        if not sig.parameters:
+                            func_no_args = typing.cast(MainCallableWithNoArgs, self._func)
+                            return func_no_args()
+                        func_with = typing.cast(MainCallableWithArgs, self._func)
+                        return func_with(rclpy.utilities.remove_ros_args(args))
+                    finally:
+                        ROSAwareProcess.current = None
+                        self._scope = None
+            finally:
+                rclpy.try_shutdown()
+        finally:
+            ROSAwareProcess.lock.release()
+
+
+def node() -> typing.Optional[rclpy.node.Node]:
+    """Gets the node of the current ROS aware process, if any."""
+    process = ROSAwareProcess.current
+    if process is None:
+        return None
+    return process.node
+
+
+def executor() -> typing.Optional[rclpy.executors.Executor]:
+    """Gets the executor of the current ROS aware process, if any."""
+    process = ROSAwareProcess.current
+    if process is None:
+        return None
+    return process.executor
+
+
+def main(*args: typing.Any, **kwargs: typing.Any) -> typing.Callable[[MainCallable], ROSAwareProcess]:
+    """Wraps a ``main``-like function in a `ROSAwareProcess` instance."""
+
+    def __decorator(func: MainCallable) -> ROSAwareProcess:
+        return ROSAwareProcess(func, *args, **kwargs)
+
+    return __decorator

--- a/bdai_ros2_wrappers/test/test_process.py
+++ b/bdai_ros2_wrappers/test/test_process.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+
+from std_srvs.srv import Trigger
+
+import bdai_ros2_wrappers.process as process
+
+
+def test_process_wrapping() -> None:
+    """Asserts that the process bound node is made available."""
+
+    @process.main(name="test_process")
+    def main() -> int:
+        def dummy_server_callback(_: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+            response.success = True
+            return response
+
+        assert main.node is not None
+        main.node.create_service(Trigger, "/dummy/trigger", dummy_server_callback)
+
+        client = main.node.create_client(Trigger, "/dummy/trigger")
+        assert client.wait_for_service(timeout_sec=10)
+
+        response = client.call(Trigger.Request())
+        assert response.success
+        return 0
+
+    assert main() == 0

--- a/bdai_ros2_wrappers/test/test_tf_listener_wrapper.py
+++ b/bdai_ros2_wrappers/test/test_tf_listener_wrapper.py
@@ -1,18 +1,16 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
 import time
-import unittest
-from threading import Thread
-from typing import Optional
+from typing import Iterable, Optional, Tuple
 
+import pytest
 import rclpy
 from geometry_msgs.msg import Quaternion, Transform, TransformStamped, Vector3
-from rclpy import Context
 from rclpy.duration import Duration
-from rclpy.executors import ExternalShutdownException, SingleThreadedExecutor
-from rclpy.node import Node
 from rclpy.time import Time
 from tf2_ros import ExtrapolationException, LookupException, TransformBroadcaster
 
+from bdai_ros2_wrappers.node import Node
+from bdai_ros2_wrappers.process import ROSAwareScope
 from bdai_ros2_wrappers.tf_listener_wrapper import TFListenerWrapper
 
 ROBOT = "test_robot"
@@ -34,23 +32,12 @@ def equal_transform(a: Transform, b: Transform) -> bool:
 
 
 class MockTfPublisherNode(Node):
-    def __init__(self, context: Context, frame_id: str, child_frame_id: str) -> None:
-        super().__init__("mock_tf_publisher", context=context)
+    def __init__(self, frame_id: str, child_frame_id: str) -> None:
+        super().__init__("mock_tf_publisher")
 
         self._frame_id = frame_id
         self._child_frame_id = child_frame_id
         self._tf_broadcaster = TransformBroadcaster(self)
-        self._executor: Optional[SingleThreadedExecutor] = SingleThreadedExecutor(context=context)
-        self._executor.add_node(self)
-        self._thread: Optional[Thread] = Thread(target=self._spin)
-        self._thread.start()
-
-    def _spin(self) -> None:
-        if self._executor is not None:
-            try:
-                self._executor.spin()
-            except (ExternalShutdownException, KeyboardInterrupt):
-                pass
 
     def publish_transform(self, trans: Transform, timestamp: Optional[Time]) -> None:
         t = TransformStamped()
@@ -64,124 +51,105 @@ class MockTfPublisherNode(Node):
 
         self._tf_broadcaster.sendTransform(t)
 
-    def shutdown(self) -> None:
-        if self._tf_broadcaster is not None:
-            self._tf_broadcaster = None
-        if self._executor is not None:
-            self._executor.shutdown()
-            self._executor.remove_node(self)
-            self._executor = None
-        if self._thread is not None:
-            self._thread.join()
-            self._thread = None
-        self.destroy_node()
+
+@pytest.fixture
+def ros() -> Iterable[ROSAwareScope]:
+    rclpy.init()
+    try:
+        with ROSAwareScope("fixture") as scope:
+            yield scope
+    finally:
+        rclpy.try_shutdown()
 
 
-class TfListenerWrapperTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.context: Optional[Context] = Context()
-        rclpy.init(context=self.context)
-        self.tf_publisher: Optional[MockTfPublisherNode] = MockTfPublisherNode(self.context, FRAME_ID, CHILD_FRAME_ID)
-        self.tf_listener: Optional[TFListenerWrapper] = TFListenerWrapper(node_name="test", context=self.context)
-
-    def tearDown(self) -> None:
-        if self.tf_listener is not None:
-            self.tf_listener.shutdown()
-            self.tf_listener = None
-        if self.tf_publisher is not None:
-            self.tf_publisher.shutdown()
-            self.tf_publisher = None
-        rclpy.shutdown(context=self.context)
-        self.context = None
-
-    def test_non_existant_transform(self) -> None:
-        if self.tf_listener is None or self.tf_publisher is None:
-            self.fail()
-        timestamp = self.tf_publisher.get_clock().now()
-        self.assertRaises(LookupException, self.tf_listener.lookup_a_tform_b, FRAME_ID, CHILD_FRAME_ID, timestamp)
-
-    def test_non_existant_transform_timeout(self) -> None:
-        if self.tf_listener is None or self.tf_publisher is None:
-            self.fail()
-        timestamp = self.tf_publisher.get_clock().now()
-        start = time.time()
-        self.assertRaises(
-            LookupException, self.tf_listener.lookup_a_tform_b, FRAME_ID, CHILD_FRAME_ID, timestamp, timeout=20.0
-        )
-        self.assertLess(time.time() - start, 10.0)
-
-    def test_existing_transform(self) -> None:
-        if self.tf_listener is None or self.tf_publisher is None:
-            self.fail()
-        timestamp = self.tf_publisher.get_clock().now()
-        trans = Transform(translation=Vector3(x=1.0, y=2.0, z=3.0), rotation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))
-        self.tf_publisher.publish_transform(trans, timestamp)
-        time.sleep(0.2)
-        t = self.tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp)
-        self.assertTrue(equal_transform(t.transform, trans))
-
-    def test_future_transform_extrapolation_exception(self) -> None:
-        if self.tf_listener is None or self.tf_publisher is None:
-            self.fail()
-        timestamp = self.tf_publisher.get_clock().now()
-        trans = Transform(translation=Vector3(x=1.0, y=2.0, z=3.0), rotation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))
-        self.tf_publisher.publish_transform(trans, timestamp)
-        time.sleep(0.2)
-        timestamp = self.tf_publisher.get_clock().now()
-        self.assertRaises(
-            ExtrapolationException, self.tf_listener.lookup_a_tform_b, FRAME_ID, CHILD_FRAME_ID, timestamp
-        )
-
-    def test_future_transform_insufficient_wait(self) -> None:
-        if self.tf_listener is None or self.tf_publisher is None:
-            self.fail()
-        timestamp = self.tf_publisher.get_clock().now()
-        trans = Transform(translation=Vector3(x=1.0, y=2.0, z=3.0), rotation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))
-        self.tf_publisher.publish_transform(trans, timestamp)
-
-        delay = 2
-
-        def _delayed_publish() -> None:
-            if self.tf_publisher is None:
-                self.fail()
-            time.sleep(delay)
-            delayed_timestamp = self.tf_publisher.get_clock().now()
-            self.tf_publisher.publish_transform(trans, delayed_timestamp)
-
-        thread = Thread(target=_delayed_publish)
-        thread.start()
-
-        time.sleep(0.2)
-        timestamp = self.tf_publisher.get_clock().now() + Duration(seconds=delay)
-        self.assertRaises(
-            ExtrapolationException, self.tf_listener.lookup_a_tform_b, FRAME_ID, CHILD_FRAME_ID, timestamp, timeout=0.5
-        )
-        thread.join()
-
-    def test_future_transform_wait(self) -> None:
-        if self.tf_listener is None or self.tf_publisher is None:
-            self.fail()
-        timestamp = self.tf_publisher.get_clock().now()
-        trans = Transform(translation=Vector3(x=1.0, y=2.0, z=3.0), rotation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))
-        self.tf_publisher.publish_transform(trans, timestamp)
-
-        delay = 1
-
-        def _delayed_publish() -> None:
-            if self.tf_publisher is None:
-                self.fail()
-            time.sleep(delay + 0.001)
-            delayed_timestamp = self.tf_publisher.get_clock().now()
-            self.tf_publisher.publish_transform(trans, delayed_timestamp)
-
-        thread = Thread(target=_delayed_publish)
-        thread.start()
-
-        timestamp += Duration(seconds=delay)
-        t = self.tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp, wait_for_frames=True, timeout=2)
-        self.assertTrue(equal_transform(t.transform, trans))
-        thread.join()
+@pytest.fixture
+def tf_pair(ros: ROSAwareScope) -> Iterable[Tuple[MockTfPublisherNode, TFListenerWrapper]]:
+    tf_publisher = MockTfPublisherNode(FRAME_ID, CHILD_FRAME_ID)
+    ros.executor.add_node(tf_publisher)
+    tf_listener = TFListenerWrapper(ros.node)
+    yield tf_publisher, tf_listener
+    ros.executor.remove_node(tf_publisher)
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_non_existant_transform(ros: ROSAwareScope, tf_pair: Tuple[MockTfPublisherNode, TFListenerWrapper]) -> None:
+    tf_publisher, tf_listener = tf_pair
+    timestamp = ros.node.get_clock().now()
+    with pytest.raises(LookupException):
+        tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp)
+
+
+def test_non_existant_transform_timeout(
+    ros: ROSAwareScope, tf_pair: Tuple[MockTfPublisherNode, TFListenerWrapper]
+) -> None:
+    tf_publisher, tf_listener = tf_pair
+    timestamp = ros.node.get_clock().now()
+    start = time.time()
+    with pytest.raises(LookupException):
+        tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp, timeout=20.0)
+    assert time.time() - start < 10.0
+
+
+def test_existing_transform(ros: ROSAwareScope, tf_pair: Tuple[MockTfPublisherNode, TFListenerWrapper]) -> None:
+    tf_publisher, tf_listener = tf_pair
+    timestamp = ros.node.get_clock().now()
+    trans = Transform(translation=Vector3(x=1.0, y=2.0, z=3.0), rotation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))
+    tf_publisher.publish_transform(trans, timestamp)
+    time.sleep(0.2)
+    t = tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp)
+    assert equal_transform(t.transform, trans)
+
+
+def test_future_transform_extrapolation_exception(
+    ros: ROSAwareScope, tf_pair: Tuple[MockTfPublisherNode, TFListenerWrapper]
+) -> None:
+    tf_publisher, tf_listener = tf_pair
+    timestamp = ros.node.get_clock().now()
+    trans = Transform(translation=Vector3(x=1.0, y=2.0, z=3.0), rotation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))
+    tf_publisher.publish_transform(trans, timestamp)
+    time.sleep(0.2)
+    timestamp = ros.node.get_clock().now()
+    with pytest.raises(ExtrapolationException):
+        tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp)
+
+
+def test_future_transform_insufficient_wait(
+    ros: ROSAwareScope, tf_pair: Tuple[MockTfPublisherNode, TFListenerWrapper]
+) -> None:
+    tf_publisher, tf_listener = tf_pair
+    timestamp = ros.node.get_clock().now()
+    trans = Transform(translation=Vector3(x=1.0, y=2.0, z=3.0), rotation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))
+    tf_publisher.publish_transform(trans, timestamp)
+
+    delay = 2
+
+    def delayed_publish() -> None:
+        time.sleep(delay)
+        delayed_timestamp = ros.node.get_clock().now()
+        tf_publisher.publish_transform(trans, delayed_timestamp)
+
+    ros.executor.create_task(delayed_publish)
+
+    time.sleep(0.2)
+    timestamp = ros.node.get_clock().now() + Duration(seconds=delay)
+    with pytest.raises(ExtrapolationException):
+        tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp, timeout=0.5)
+
+
+def test_future_transform_wait(ros: ROSAwareScope, tf_pair: Tuple[MockTfPublisherNode, TFListenerWrapper]) -> None:
+    tf_publisher, tf_listener = tf_pair
+    timestamp = ros.node.get_clock().now()
+    trans = Transform(translation=Vector3(x=1.0, y=2.0, z=3.0), rotation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))
+    tf_publisher.publish_transform(trans, timestamp)
+
+    delay = 1
+
+    def delayed_publish() -> None:
+        time.sleep(delay + 0.001)
+        delayed_timestamp = tf_publisher.get_clock().now()
+        tf_publisher.publish_transform(trans, delayed_timestamp)
+
+    ros.executor.create_task(delayed_publish)
+
+    timestamp += Duration(seconds=delay)
+    t = tf_listener.lookup_a_tform_b(FRAME_ID, CHILD_FRAME_ID, timestamp, wait_for_frames=True, timeout=2)
+    assert equal_transform(t.transform, trans)


### PR DESCRIPTION
Owing to the nature of most indirect and direct use of these wrappers in BDAII's codebase, this PR re-introduces the concept of a process-wide node, served in the background.