### PR TITLE
Add `wait_for_message` utilities

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/subscription.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/subscription.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+import threading
+import typing
+
+import rclpy.node
+import rclpy.qos
+import rclpy.task
+
+import bdai_ros2_wrappers.process as process
+
+MessageT = typing.TypeVar("MessageT")
+
+
+def wait_for_message_async(
+    msg_type: MessageT,
+    topic_name: str,
+    *,
+    qos_profile: typing.Union[rclpy.qos.QoSProfile, int] = 1,
+    node: typing.Optional[rclpy.node.Node] = None,
+) -> rclpy.task.Future:
+    """
+    Wait for message on a given topic asynchronously.
+
+    Args:
+        msg_type: type of message to wait for.
+        topic_name: name of the topic to wait on.
+        qos_profile: optional QoS profile for temporary topic subscription.
+        node: optional node for temporary topic subscription, defaults to
+        the current process-wide node (if any).
+
+    Returns:
+        A future for the incoming message.
+
+    Raises:
+        RuntimeError: if no node is available.
+    """
+    node = node or process.node()
+    if node is None:
+        raise ValueError("No process-wide ROS 2 node available (did you use bdai_ros2_wrapper.process.main?)")
+    future = rclpy.task.Future()
+
+    def callback(msg: MessageT) -> None:
+        if not future.done():
+            future.set_result(msg)
+
+    sub = node.create_subscription(msg_type, topic_name, callback, qos_profile)
+    future.add_done_callback(lambda future: node.destroy_subscription(sub))
+    return future
+
+
+def wait_for_message(
+    msg_type: MessageT, topic_name: str, timeout_sec: typing.Optional[float] = None, **kwargs: typing.Any
+) -> typing.Optional[MessageT]:
+    """
+    Wait for message on a given topic synchronously.
+
+    Args:
+        msg_type: type of message to wait for.
+        topic_name: name of the topic to wait on.
+        timeout_sec: optional timeout, in seconds, for the wait.
+
+    See `wait_for_message_async` documentation for a reference on
+    additional keyword arguments.
+
+    Returns:
+        The message received, or None on timeout.
+    """
+    event = threading.Event()
+    future = wait_for_message_async(msg_type, topic_name, **kwargs)
+    future.add_done_callback(lambda future: event.set())
+    if not event.wait(timeout_sec):
+        return None
+    return future.result()

--- a/bdai_ros2_wrappers/test/test_subscription.py
+++ b/bdai_ros2_wrappers/test/test_subscription.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+import time
+import typing
+
+import pytest
+import rclpy
+from std_msgs.msg import Int8
+
+from bdai_ros2_wrappers.process import ROSAwareScope
+from bdai_ros2_wrappers.subscription import wait_for_message
+
+
+@pytest.fixture
+def ros() -> typing.Iterable[ROSAwareScope]:
+    rclpy.init()
+    try:
+        with ROSAwareScope("fixture") as scope:
+            yield scope
+    finally:
+        rclpy.try_shutdown()
+
+
+def test_wait_for_message(ros: ROSAwareScope) -> None:
+    """Asserts that wait for message works as expected."""
+    pub = ros.node.create_publisher(Int8, "test", 1)
+    assert not wait_for_message(Int8, "test", node=ros.node, timeout_sec=0.5)
+
+    def deferred_publish() -> None:
+        time.sleep(1.0)
+        pub.publish(Int8(data=1))
+
+    ros.executor.create_task(deferred_publish)
+    message = wait_for_message(Int8, "test", node=ros.node, timeout_sec=10.0)
+    assert message is not None
+    assert message.data == 1


### PR DESCRIPTION
This patch adds `wait_for_message` APIs, in synchronous and asynchronous flavors. These APIs, unlike the one upstream, are compatible with nodes already associated to an executor and potentially spinning. Builds on #25. 