### PR TITLE
Extend process-wide machinery to handle more idioms

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/executors.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/executors.py
@@ -2,6 +2,7 @@
 import atexit
 import collections
 import concurrent.futures
+import contextlib
 import dataclasses
 import inspect
 import logging
@@ -13,7 +14,7 @@ import weakref
 
 import rclpy.executors
 
-from bdai_ros2_wrappers.utilities import fqn
+from bdai_ros2_wrappers.utilities import bind_to_thread, fqn
 
 
 class AutoScalingThreadPool(concurrent.futures.Executor):
@@ -645,3 +646,51 @@ class AutoScalingMultiThreadedExecutor(rclpy.executors.Executor):
                     task = AutoScalingMultiThreadedExecutor.Task(task, entity)
                     task.cancel()
         return done
+
+
+@contextlib.contextmanager
+def background(executor: rclpy.executors.Executor) -> typing.Iterator[rclpy.executors.Executor]:
+    """
+    Pushes an executor to a background thread.
+
+    Upon context entry, the executor starts spinning in a background thread.
+    Upon context exit, the executor is shutdown and the background thread is joined.
+
+    Args:
+        executor: executor to be managed.
+
+    Returns:
+        a context manager.
+    """
+    background_thread = threading.Thread(target=executor.spin)
+    executor.spin = bind_to_thread(executor.spin, background_thread)
+    executor.spin_once = bind_to_thread(executor.spin_once, background_thread)
+    executor.spin_until_future_complete = bind_to_thread(executor.spin_until_future_complete, background_thread)
+    executor.spin_once_until_future_complete = bind_to_thread(
+        executor.spin_once_until_future_complete, background_thread
+    )
+    background_thread.start()
+    try:
+        yield executor
+    finally:
+        executor.shutdown()
+        background_thread.join()
+
+
+@contextlib.contextmanager
+def foreground(executor: rclpy.executors.Executor) -> typing.Iterator[rclpy.executors.Executor]:
+    """
+    Manages an executor in the current thread.
+
+    Upon context exit, the executor is shutdown.
+
+    Args:
+        executor: executor to be managed.
+
+    Returns:
+        a context manager.
+    """
+    try:
+        yield executor
+    finally:
+        executor.shutdown()

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/node.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/node.py
@@ -8,9 +8,13 @@ from bdai_ros2_wrappers.callback_groups import NonReentrantCallbackGroup
 
 
 class Node(BaseNode):
-    """An rclpy.node.Node subclass that changes the default callback group to be non-reentrant."""
+    """
+    An rclpy.node.Node subclass that:
 
-    def __init__(self, *args: Any, default_callback_group: Optional[CallbackGroup] = None, **kwargs: Any):
+    * changes the default callback group to be non-reentrant.
+    """
+
+    def __init__(self, *args: Any, default_callback_group: Optional[CallbackGroup] = None, **kwargs: Any) -> None:
         """
         Initializes the node.
 

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/process.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/process.py
@@ -9,138 +9,27 @@ import typing
 
 import rclpy
 import rclpy.executors
+import rclpy.logging
 import rclpy.node
 
-from bdai_ros2_wrappers.executors import AutoScalingMultiThreadedExecutor
-from bdai_ros2_wrappers.logging import logs_to_ros
-from bdai_ros2_wrappers.node import Node
+import bdai_ros2_wrappers.scope as scope
+from bdai_ros2_wrappers.scope import AnyEntity, AnyEntityFactoryCallable, ROSAwareScope
 from bdai_ros2_wrappers.utilities import either_or
 
-
-class ROSAwareScope(typing.ContextManager["ROSAwareScope"]):
-    """
-    A context manager to enable ROS code in a given scope by providing
-    an `rclpy` node and an autoscaling multi-threaded executor spinning
-    in a background thread.
-    """
-
-    def __init__(
-        self,
-        name: str,
-        context: typing.Optional[rclpy.context.Context] = None,
-        node_args: typing.Optional[typing.Dict[str, typing.Any]] = None,
-        executor_args: typing.Optional[typing.Dict[str, typing.Any]] = None,
-        forward_logging: bool = True,
-    ):
-        """
-        Initializes the ROS aware scope.
-
-        Args:
-            name: name for this scope, and for the underlying node.
-            context: optional context for the underlying node.
-            node_args: optional keyword arguments for the underlying node.
-            executor_args: optional keyword arguments for the underlying executor.
-            forward_logging: whether to forward `logging` logs to ROS 2 logging system or not.
-        """
-        self._name = name
-        self._context = context
-        self._forward_logging = forward_logging
-        self._node: typing.Optional[rclpy.node.Node] = None
-        self._node_args: typing.Dict[str, typing.Any] = node_args or {}
-        self._executor: typing.Optional[rclpy.executors.Executor] = None
-        self._executor_args: typing.Dict[str, typing.Any] = executor_args or {}
-        self._background_thread: typing.Optional[threading.Thread] = None
-        self._logging_scope: typing.Optional[typing.ContextManager] = None
-        self._active = False
-
-    def __enter__(self) -> "ROSAwareScope":
-        """
-        Activates scope.
-
-        An active scope cannot be re-entered.
-        """
-        if self._active:
-            raise RuntimeError("cannot enter active scope")
-        self._node = Node(self._name, context=self._context, **self._node_args)
-        try:
-            self._executor = AutoScalingMultiThreadedExecutor(
-                context=self._context, logger=self._node.get_logger(), **self._executor_args
-            )
-            self._background_thread = threading.Thread(target=self._executor.spin)
-
-            try:
-                self._executor.add_node(self._node)
-                self._background_thread.start()
-                if self._forward_logging:
-                    self._logging_scope = logs_to_ros(self._node)
-                    assert self._logging_scope is not None
-                    self._logging_scope.__enter__()
-            except:
-                self._executor.shutdown()
-                self._executor = None
-                self._background_thread = None
-                raise
-            self._active = True
-            return self
-        except:
-            self._node.destroy_node()
-            self._node = None
-            raise
-
-    def __exit__(self, *exc: typing.Any) -> None:
-        """
-        Deactivates scope.
-
-        An inactive scope cannot be deactivated.
-        """
-        if not self._active:
-            raise RuntimeError("cannot exit inactive scope")
-        assert self._executor is not None
-        assert self._background_thread is not None
-        assert self._node is not None
-        if self._forward_logging:
-            assert self._logging_scope is not None
-            self._logging_scope.__exit__(*exc)
-            self._logging_scope = None
-        self._executor.shutdown()
-        self._executor = None
-        self._background_thread.join()
-        self._background_thread = None
-        self._node.destroy_node()
-        self._node = None
-        self._active = False
-
-    @property
-    def node(self) -> rclpy.node.Node:
-        """Scope node, if active."""
-        if not self._active:
-            raise RuntimeError("scope is not active")
-        assert self._node is not None
-        return self._node
-
-    @property
-    def executor(self) -> rclpy.executors.Executor:
-        """Scope executor, if active."""
-        if not self._active:
-            raise RuntimeError("scope is not active")
-        assert self._executor is not None
-        return self._executor
-
-
 MainCallableTakingArgs = typing.Callable[[argparse.Namespace], typing.Optional[int]]
-MainCallableTakingArgv = typing.Callable[[typing.Optional[typing.Sequence[str]]], typing.Optional[int]]
+MainCallableTakingArgv = typing.Callable[[typing.Sequence[str]], typing.Optional[int]]
 MainCallableTakingNoArgs = typing.Callable[[], typing.Optional[int]]
 MainCallable = typing.Union[MainCallableTakingNoArgs, MainCallableTakingArgv, MainCallableTakingArgs]
 
 
 class ROSAwareProcess:
     """
-    A ``main``-like function wrapper that binds a ROS aware scope to each function invocation.
+    A ``main``-like function wrapper that binds a ROS 2 aware scope to each function invocation.
 
     Only one process can be invoked at a time, becoming the ``current`` process.
     This enables global access to the process and, in consequence, to its scope.
 
-    This wrapper will rarely be used explicitly but through the `wrap` decorator.
+    This wrapper is rarely be used explicitly but through the `main` decorator.
     """
 
     lock = threading.Lock()
@@ -150,48 +39,87 @@ class ROSAwareProcess:
     def __init__(
         self,
         func: MainCallable,
-        name: typing.Optional[str] = None,
+        *,
+        prebaked: bool = True,
+        autospin: typing.Optional[bool] = None,
+        forward_logging: typing.Optional[bool] = None,
+        namespace: typing.Optional[typing.Union[typing.Literal[True], str]] = None,
         cli: typing.Optional[argparse.ArgumentParser] = None,
-        init_args: typing.Optional[typing.Dict[str, typing.Any]] = None,
-        node_args: typing.Optional[typing.Dict[str, typing.Any]] = None,
-        executor_args: typing.Optional[typing.Dict[str, typing.Any]] = None,
-        forward_logging: bool = True,
+        **init_arguments: typing.Any,
     ):
         """
-        Initializes the ROS aware process.
+        Initializes the ROS 2 aware process.
 
         Args:
-            func: a ``main``-like function to wrap.
-            name: an optional name for this process and the underlying node.
-            If not provided, the basename without extension of the calling executable will be used.
+            func: a ``main``-like function to wrap ie. a callable taking a sequence of strings,
+            an `argparse.Namespace` (if a CLI is specified), or nothing, and returning a integer
+            exit code or nothing.
+            prebaked: whether to instantiate a prebaked or a bare process. Bare processes do not bear
+            a node nor spin an executor, which brings them closest to standard ROS 2 idioms.
+            autospin: whether to automatically equip the underlying scope with a background executor
+            or not. Defaults to True for prebaked processes and to False for bare processes.
+            forward_logging: whether to forward `logging` logs to the ROS 2 logging system or not.
+            Defaults to True for prebaked processes and to False for bare processes (though it requires
+            a process node to be set to function).
+            namespace: an optional namespace for this process. If True, the current executable basename
+            without its extension (or CLI program name if one is specified) will be used. Defaults to
+            True for prebaked processes.
+            cli: optional command-line interface argument parser.
 
-        Additional keyword arguments will be forwarded to the process' `ROSAwareScope` instance.
+        Raises:
+            ValueError: if a prebaked process is configured without autospin.
         """
-        self._func = func
-        if name is None:
+        if forward_logging is None:
+            forward_logging = prebaked
+        if autospin is None:
+            autospin = prebaked
+        if prebaked and not autospin:
+            raise ValueError("prebaked process must autospin")
+        if namespace is None and prebaked:
+            namespace = True
+        if namespace is True:
             if cli is None:
                 program_name = os.path.basename(sys.argv[0])
             else:
                 program_name = cli.prog
-            name, _ = os.path.splitext(program_name)
-        self._name = name
+            namespace, _ = os.path.splitext(program_name)
+        self._func = func
         self._cli = cli
-        self._init_args = init_args or {}
-        self._node_args = node_args or {}
-        self._executor_args = executor_args or {}
-        self._forward_logging = forward_logging
+        self._scope_kwargs = dict(
+            prebaked=prebaked, autospin=autospin, namespace=namespace, forward_logging=forward_logging
+        )
         self._scope: typing.Optional[ROSAwareScope] = None
+        self._lock = threading.Lock()
         functools.update_wrapper(self, self._func)
 
     def __getattr__(self, name: str) -> typing.Any:
-        """Gets attribute from scope, if any."""
-        if self._scope is None:
-            return super().__getattribute__(name)
-        return getattr(self._scope, name)
+        """
+        Gets missing attributes from the underlying scope.
+
+        Raises:
+            RuntimeError: if the process is not executing.
+        """
+        with self._lock:
+            if self._scope is None:
+                raise RuntimeError("process is not executing")
+            return getattr(self._scope, name)
+
+    def __setattr__(self, name: str, value: typing.Any) -> None:
+        """
+        Sets public attributes on the underlying scope when possible.
+
+        Args:
+            name: name of the attribute to be set
+            value: attribute value to be set.
+        """
+        if not name.startswith("_") and hasattr(self._scope, name):
+            setattr(self._scope, name, value)
+            return
+        super().__setattr__(name, value)
 
     def __call__(self, argv: typing.Optional[typing.Sequence[str]] = None) -> typing.Optional[int]:
         """
-        Invokes wrapped function in a ROS aware scope.
+        Invokes wrapped process function in a ROS 2 aware scope.
 
         Args:
             argv: optional command line-like arguments.
@@ -200,58 +128,134 @@ class ROSAwareProcess:
             an optional return code.
 
         Raises:
-            RuntimeError: if a ROS aware process is already running.
+            RuntimeError: if a ROS 2 aware process is already running.
         """
         if not ROSAwareProcess.lock.acquire(blocking=False):
-            raise RuntimeError("Process already running!")
-
-        args = None
-        if self._cli is not None:
-            args = self._cli.parse_args(rclpy.utilities.remove_ros_args(argv)[1:])
-
+            raise RuntimeError("process already running")
+        self._lock.acquire()
         try:
-            rclpy.init(args=argv, **either_or(args, "init_args", self._init_args))
-            try:
-                context = rclpy.get_default_context()
-                node_args = either_or(args, "node_args", self._node_args)
-                executor_args = either_or(args, "executor_args", self._executor_args)
-                forward_logging = either_or(args, "forward_logging", self._forward_logging)
-                with ROSAwareScope(self._name, context, node_args, executor_args, forward_logging) as scope:
-                    self._scope = scope
-                    ROSAwareProcess.current = self
-                    try:
-                        sig = inspect.signature(self._func)
-                        if not sig.parameters:
-                            func_taking_no_args = typing.cast(MainCallableTakingNoArgs, self._func)
-                            return func_taking_no_args()
-                        if args is not None:
-                            func_taking_args = typing.cast(MainCallableTakingArgs, self._func)
-                            return func_taking_args(args)
-                        func_taking_argv = typing.cast(MainCallableTakingArgv, self._func)
-                        return func_taking_argv(rclpy.utilities.remove_ros_args(argv))
-                    finally:
-                        ROSAwareProcess.current = None
-                        self._scope = None
-            finally:
-                rclpy.try_shutdown()
+            args = None
+            if self._cli is not None:
+                args = self._cli.parse_args(rclpy.utilities.remove_ros_args(argv)[1:])
+            scope_kwargs = either_or(args, "scope_args", self._scope_kwargs)
+            with scope.top(argv, global_=True, **scope_kwargs) as self._scope:
+                ROSAwareProcess.current = self
+                self._lock.release()
+                try:
+                    sig = inspect.signature(self._func)
+                    if not sig.parameters:
+                        func_taking_no_args = typing.cast(MainCallableTakingNoArgs, self._func)
+                        return func_taking_no_args()
+                    if args is not None:
+                        func_taking_args = typing.cast(MainCallableTakingArgs, self._func)
+                        return func_taking_args(args)
+                    func_taking_argv = typing.cast(MainCallableTakingArgv, self._func)
+                    return func_taking_argv(rclpy.utilities.remove_ros_args(argv))
+                finally:
+                    self._lock.acquire()
+                    ROSAwareProcess.current = None
+                    self._scope = None
+        except KeyboardInterrupt:
+            return None  # ignore
         finally:
+            self._lock.release()
             ROSAwareProcess.lock.release()
+
+    def try_shutdown(self) -> None:
+        """Atempts to shutdown the underlying scope context."""
+        with self._lock:
+            if self._scope is None:
+                raise RuntimeError("process is not executing")
+            rclpy.try_shutdown(context=self._scope.context)
+
+
+def current() -> typing.Optional[ROSAwareProcess]:
+    """Gets the current ROS 2 aware process, if any."""
+    return ROSAwareProcess.current
 
 
 def node() -> typing.Optional[rclpy.node.Node]:
-    """Gets the node of the current ROS aware process, if any."""
-    process = ROSAwareProcess.current
+    """Gets the node of the current ROS 2 aware process, if any."""
+    process = current()
     if process is None:
         return None
     return process.node
 
 
 def executor() -> typing.Optional[rclpy.executors.Executor]:
-    """Gets the executor of the current ROS aware process, if any."""
-    process = ROSAwareProcess.current
+    """Gets the executor of the current ROS 2 aware process, if any."""
+    process = current()
     if process is None:
         return None
     return process.executor
+
+
+def load(factory: AnyEntityFactoryCallable, *args: typing.Any, **kwargs: typing.Any) -> AnyEntity:
+    """
+    Loads a ROS 2 node (or a collection thereof) within the current ROS 2 aware process scope.
+
+    See `ROSAwareProcess` and `ROSAwareScope.load` documentation for further
+    reference on positional and keyword arguments taken by this function.
+
+    Raises:
+        RuntimeError: if no process is executing.
+    """
+    process = current()
+    if process is None:
+        raise RuntimeError("no process is executing")
+    return process.load(factory, *args, **kwargs)
+
+
+def unload(loaded: AnyEntity) -> None:
+    """
+    Unloads a ROS 2 node (or a collection thereof) from the current ROS 2 aware process scope.
+
+    See `ROSAwareProcess` and `ROSAwareScope.unload` documentation for further
+    reference on positional and keyword arguments taken by this function.
+
+    Raises:
+        RuntimeError: if no process is executing.
+    """
+    process = current()
+    if process is None:
+        raise RuntimeError("no process is executing")
+    process.unload(loaded)
+
+
+def managed(
+    factory: AnyEntityFactoryCallable, *args: typing.Any, **kwargs: typing.Any
+) -> typing.ContextManager[AnyEntity]:
+    """
+    Manages a ROS 2 node (or a collection thereof) within the current ROS 2 aware process scope.
+
+    See `ROSAwareProcess` and `ROSAwareScope.managed` documentation for further
+    reference on positional and keyword arguments taken by this function.
+
+    Raises:
+        RuntimeError: if no process is executing.
+    """
+    process = current()
+    if process is None:
+        raise RuntimeError("no process is executing")
+    return process.managed(factory, *args, **kwargs)
+
+
+def spin(factory: typing.Optional[AnyEntityFactoryCallable] = None, *args: typing.Any, **kwargs: typing.Any) -> None:
+    """
+    Spins current ROS 2 aware process executor (and all ROS 2 nodes in it).
+
+    Optionally, manages a ROS 2 node (or a collection thereof) for as long as it spins.
+
+    See `ROSAwareProcess` and `ROSAwareScope.spin` documentation for further
+    reference on positional and keyword arguments taken by this function.
+
+    Raises:
+        RuntimeError: if no process is executing.
+    """
+    process = current()
+    if process is None:
+        raise RuntimeError("no process is executing")
+    process.spin(factory, *args, **kwargs)
 
 
 def main(
@@ -263,3 +267,11 @@ def main(
         return ROSAwareProcess(func, cli=cli, **kwargs)
 
     return __decorator
+
+
+def try_shutdown() -> None:
+    """Attempts to shutdown the context associated with the current ROS 2 aware process."""
+    process = current()
+    if process is None:
+        raise RuntimeError("no process is executing")
+    process.try_shutdown()

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/scope.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/scope.py
@@ -1,0 +1,551 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+import contextlib
+import os
+import threading
+import typing
+
+import rclpy
+import rclpy.executors
+import rclpy.logging
+import rclpy.node
+
+from bdai_ros2_wrappers.executors import AutoScalingMultiThreadedExecutor, background, foreground
+from bdai_ros2_wrappers.logging import logs_to_ros
+from bdai_ros2_wrappers.node import Node
+from bdai_ros2_wrappers.utilities import fqn, namespace_with
+
+AnyEntity = typing.Union[rclpy.node.Node, typing.List[rclpy.node.Node]]
+NodeFactoryCallable = typing.Callable[..., rclpy.node.Node]
+GraphFactoryCallable = typing.Callable[..., typing.Iterable[rclpy.node.Node]]
+AnyEntityFactoryCallable = typing.Union[NodeFactoryCallable, GraphFactoryCallable]
+
+
+class ROSAwareScope(typing.ContextManager["ROSAwareScope"]):
+    """
+    A context manager to enable ROS 2 code in a given scope by providing
+    an `rclpy` node and an autoscaling multi-threaded executor spinning
+    in a background thread.
+    """
+
+    global_: typing.Optional["ROSAwareScope"] = None
+
+    class LocalStack(threading.local):
+        top: typing.Optional["ROSAwareScope"] = None
+
+    local = LocalStack()
+
+    def __init__(
+        self,
+        *,
+        prebaked: bool = True,
+        global_: bool = False,
+        namespace: typing.Optional[str] = None,
+        autospin: typing.Optional[bool] = None,
+        forward_logging: bool = False,
+        context: typing.Optional[rclpy.context.Context] = None,
+    ) -> None:
+        """
+        Initializes the ROS 2 aware scope.
+
+        Args:
+            prebaked: whether to include an implicit main node in the scope graph
+            or not, for convenience. Prebaked scopes must autospin.
+            global_: whether to make this scope global (ie. accessible from all threads).
+            Only one, outermost global scope can be entered at any given time. Global
+            scopes can only be entered from the main thread.
+            namespace: optional namespace for all underlying nodes. Defaults to
+            a unique hidden namespace.
+            autospin: whether to automatically instantiate and push an executor
+            to a background thread on scope entry or not.
+            forward_logging: whether to forward `logging` logs to the ROS 2 logging
+            system or not. Defaults to False.
+            context: optional context for the underlying executor and nodes.
+        """
+        if autospin is None:
+            autospin = prebaked
+        if prebaked and not autospin:
+            raise ValueError("prebaked scope must autospin")
+        if namespace is None:
+            namespace = f"_ros_aware_scope_{os.getpid()}_{id(self)}"
+        self._namespace = namespace
+        self._context = context
+        self._prebaked = prebaked
+        self._autospin = autospin
+        self._forward_logging = forward_logging
+        self._global = global_
+        self._lock = threading.Lock()
+        self._node: typing.Optional[rclpy.node.Node] = None
+        self._graph: typing.List[rclpy.node.Node] = []
+        self._executor: typing.Optional[rclpy.executors.Executor] = None
+        self._stack: typing.Optional[contextlib.ExitStack] = None
+        self._owner: typing.Optional[threading.Thread] = None
+        self._parent: typing.Optional[ROSAwareScope] = None
+
+    @property
+    def context(self) -> typing.Optional[rclpy.context.Context]:
+        """Gets scope context (may be ``None`` if default)."""
+        return self._context
+
+    def __enter__(self) -> "ROSAwareScope":
+        """
+        Enters scope.
+
+        Scopes are not reentrant.
+
+        Raises:
+            RuntimeError: if scope has been entered already, or, if global, when
+            attempting to enter from a thread other than the main thread, when
+            a global scope has already been entered, and when scope is not the
+            outermost scope.
+        """
+        with self._lock:
+            if self._stack is not None:
+                raise RuntimeError("scope has been entered already")
+
+            if self._global:
+                if threading.current_thread() is not threading.main_thread():
+                    raise RuntimeError("a global scope can only be entered from main thread")
+                if ROSAwareScope.global_ is not None:
+                    raise RuntimeError("a global scope has been entered already")
+                if ROSAwareScope.local.top is not None:
+                    raise RuntimeError("a global scope must be entered before any local scopes")
+
+            self._stack = contextlib.ExitStack()
+            self._owner = threading.current_thread()
+
+            if self._autospin:
+                logger = rclpy.logging.get_logger(self._namespace.replace("/", ".").strip("."))
+                self._executor = self._stack.enter_context(
+                    background(AutoScalingMultiThreadedExecutor(logger=logger, context=self._context))
+                )
+
+                if self._prebaked:
+                    node = Node("node", namespace=self._namespace, context=self._context)
+                    self._executor.add_node(node)
+                    self._graph.append(node)
+                    if self._forward_logging:
+                        self._stack.enter_context(logs_to_ros(node))
+                    self._node = node
+
+            if self._global:
+                ROSAwareScope.global_ = self
+            self._parent = ROSAwareScope.local.top
+            ROSAwareScope.local.top = self
+            return self
+
+    def __exit__(self, *exc: typing.Any) -> None:
+        """
+        Exits scope.
+
+        Raises:
+            RuntimeError: if scope has not been entered (or already exited)
+            or if scope was entered from a different thread.
+        """
+        with self._lock:
+            if self._stack is None:
+                raise RuntimeError("scope has not been entered (or already exited)")
+            if self._owner is not threading.current_thread():
+                raise RuntimeError("scope entered from a different thread")
+            ROSAwareScope.local.top = self._parent
+            if self._global:
+                ROSAwareScope.global_ = None
+            self._parent = None
+            self._stack.close()
+            self._stack = None
+            self._owner = None
+            assert self._executor is not None
+            for node in self._graph:
+                self._executor.remove_node(node)
+                node.destroy_node()
+            self._graph.clear()
+            self._executor = None
+            self._node = None
+
+    @property
+    def graph(self) -> typing.List[rclpy.node.Node]:
+        """Gets scope nodes, if any."""
+        return list(self._graph)
+
+    @property
+    def executor(self) -> typing.Optional[rclpy.executors.Executor]:
+        """Gets scope executor, if any."""
+        return self._executor
+
+    @executor.setter
+    def executor(self, executor: rclpy.executors.Executor) -> None:
+        """
+        Sets scope executor.
+
+        Args:
+            executor: executor to be used.
+
+        Raises:
+            RuntimeError: if scope has not been entered (or already exited)
+            or an scope executor is already set.
+        """
+        with self._lock:
+            if self._stack is None:
+                raise RuntimeError("scope has not been entered (or already exited)")
+            if self._executor is not None:
+                raise RuntimeError("scope executor already set")
+            self._executor = executor
+
+    @property
+    def node(self) -> typing.Optional[rclpy.node.Node]:
+        """Gets scope main node, if any."""
+        return self._node
+
+    @node.setter
+    def node(self, node: rclpy.node.Node) -> None:
+        """
+        Sets scope main node.
+
+        Args:
+            node: node to be promoted to main node. It must be a node known to the scope.
+
+        Raises:
+            RuntimeError: if the scope has not been entered (or already exited), if a
+            a scope main node has been set already, or if the node is foreign to the scope.
+        """
+        with self._lock:
+            if self._stack is None:
+                raise RuntimeError("scope has not been entered (or already exited)")
+            if self._node is not None:
+                raise RuntimeError("main scope node already set")
+            if node not in self._graph:
+                raise RuntimeError("node is not in scope")
+            if self._forward_logging:
+                self._stack.enter_context(logs_to_ros(node))
+            self._node = node
+
+    @typing.overload
+    def managed(
+        self, factory: NodeFactoryCallable, *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.ContextManager[rclpy.node.Node]:
+        """
+        Manages a ROS 2 node within scope.
+
+        Upon context entry, a ROS 2 node is instantiated and loaded.
+        Upon context exit, that ROS 2 node is unloaded and destroyed.
+
+        See `ROSAwareScope.load` documentation for further reference
+        on positional and keyword arguments taken by this method.
+
+        Returns:
+            a context manager for the loaded node.
+        """
+
+    @typing.overload
+    def managed(
+        self, factory: GraphFactoryCallable, *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.ContextManager[typing.List[rclpy.node.Node]]:
+        """
+        Manages a collection (or graph) of ROS 2 nodes within scope.
+
+        Upon context entry, ROS 2 nodes are instantiated and loaded.
+        Upon context exit, those ROS 2 nodes are unloaded and destroyed.
+
+        See `ROSAwareScope.load` documentation for further reference
+        on positional and keyword arguments taken by this method.
+
+        Returns:
+            a context manager for the loaded nodes.
+        """
+
+    @contextlib.contextmanager
+    def managed(
+        self, factory: AnyEntityFactoryCallable, *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.Iterator[AnyEntity]:
+        loaded = self.load(factory, *args, **kwargs)
+        try:
+            yield loaded
+        finally:
+            self.unload(loaded)
+
+    @typing.overload
+    def load(self, factory: NodeFactoryCallable, *args: typing.Any, **kwargs: typing.Any) -> rclpy.node.Node:
+        """
+        Instantiates and loads a ROS 2 node.
+
+        Args:
+            factory: callable to instantiate a ROS 2 node.
+            It is expected to accept `rclpy.node.Node` arguments.
+            Note it can be an `rclpy.node.Node` subclass object.
+            args: optional positional arguments for ``node_factory``.
+            kwargs: optional keyword arguments for ``node_factory``.
+
+        Returns:
+            loaded ROS 2 node.
+
+        Raises:
+            RuntimeError: if scope has not been entered (or already exited)
+            or an scope executor has not been set yet.
+        """
+
+    @typing.overload
+    def load(
+        self, factory: GraphFactoryCallable, *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.List[rclpy.node.Node]:
+        """
+        Instantiates and loads a collection (or graph) of ROS 2 nodes.
+
+        Args:
+            factory: callable to instantiate a collection of ROS 2 nodes.
+            It is expected to accept `rclpy.node.Node` arguments.
+            args: optional positional arguments for `graph_factory`.
+            kwargs: optional keyword arguments for `graph_factory`.
+
+        Returns:
+            loaded ROS 2 nodes.
+
+        Raises:
+            RuntimeError: if scope has not been entered (or already exited) or
+            an scope executor has not been set yet.
+        """
+
+    def load(
+        self,
+        factory: AnyEntityFactoryCallable,
+        *args: typing.Any,
+        namespace: typing.Optional[str] = None,
+        **kwargs: typing.Any,
+    ) -> AnyEntity:
+        with self._lock:
+            if self._stack is None:
+                raise RuntimeError("scope has not been entered (or was already exited)")
+            if self._executor is None:
+                raise RuntimeError("scope executor has not been set")
+            if namespace is not None:
+                namespace = namespace_with(self._namespace, namespace)
+            else:
+                namespace = self._namespace
+            node_or_graph = factory(*args, context=self._context, namespace=namespace, **kwargs)
+            if not isinstance(node_or_graph, rclpy.node.Node):
+                graph = list(node_or_graph)
+                for node in graph:
+                    self._executor.add_node(node)
+                self._graph.extend(graph)
+                return graph
+            node = node_or_graph
+            self._executor.add_node(node)
+            self._graph.append(node)
+            return node
+
+    def unload(self, loaded: AnyEntity) -> None:
+        """
+        Unloads and destroys ROS 2 nodes.
+
+        Args:
+            loaded: ROS 2 node or a collection thereof to unload.
+
+        Raises:
+            RuntimeError: if scope has not been entered (or already exited) or
+            an scope executor has not been set yet.
+            ValueError: if any given ROS 2 node is not found in the scope graph.
+        """
+        with self._lock:
+            if self._stack is None:
+                raise RuntimeError("scope has not been entered (or already exited)")
+            if self._executor is None:
+                raise RuntimeError("scope executor has not been set")
+            graph = [loaded] if isinstance(loaded, rclpy.node.Node) else loaded
+            if any(node for node in graph if node not in self._graph):
+                raise ValueError("node unknown (unloaded already?)")
+            for node in graph:
+                self._executor.remove_node(node)
+                self._graph.remove(node)
+                node.destroy_node()
+
+    @typing.overload
+    def spin(self) -> None:
+        """
+        Spins scope executor (and all nodes in it).
+
+        If no scope executor was set, a default one is.
+
+        Raises:
+            RuntimeError: if scope has not been entered (or already exited) or
+            the scope executor was configured to spin automatically.
+        """
+
+    @typing.overload
+    def spin(self, factory: NodeFactoryCallable, *args: typing.Any, **kwargs: typing.Any) -> None:
+        """
+        Spins scope executor (and all nodes in it).
+
+        Additionally, and for as long as it spins, a ROS 2 node is loaded.
+        If no scope executor was set, a default one is.
+
+        Args:
+            factory: callable to instantiate a ROS 2 node.
+            It is expected to accept `rclpy.node.Node` arguments.
+            Note it can be an `rclpy.node.Node` subclass object.
+            args: optional positional arguments for ``node_factory``.
+            kwargs: optional keyword arguments for ``node_factory``.
+
+        Raises:
+            RuntimeError: if scope has not been entered (or already exited) or
+            the scope executor was configured to spin automatically.
+        """
+
+    @typing.overload
+    def spin(self, factory: GraphFactoryCallable, *args: typing.Any, **kwargs: typing.Any) -> None:
+        """
+        Spins scope executor (and all nodes in it).
+
+        Additionally, and for as long as it spins, a collection of ROS 2 nodes is loaded.
+        If no scope executor was set, a default one is.
+
+        Args:
+            factory: callable to instantiate a collection of ROS 2 nodes.
+            It is expected to accept `rclpy.node.Node` arguments.
+            args: optional positional arguments for `graph_factory`.
+            kwargs: optional keyword arguments for `graph_factory`.
+
+        Raises:
+            RuntimeError: if scope has not been entered (or already exited) or
+            the scope executor was configured to spin automatically.
+        """
+
+    def spin(
+        self, factory: typing.Optional[AnyEntityFactoryCallable] = None, *args: typing.Any, **kwargs: typing.Any
+    ) -> None:
+        if self._stack is None:
+            raise RuntimeError("scope has not been entered (or already exited)")
+        if self._autospin:
+            raise RuntimeError("scope executor already spinning")
+        with self._lock:
+            if self._executor is None:
+                logger = rclpy.logging.get_logger(self._namespace or fqn(self.__class__))
+                self._executor = self._stack.enter_context(
+                    foreground(AutoScalingMultiThreadedExecutor(logger=logger, context=self._context))
+                )
+        with contextlib.ExitStack() as stack:
+            if factory is not None:
+                cm = self.managed(factory, *args, **kwargs)
+                stack.enter_context(cm)
+            self._executor.spin()
+
+
+@contextlib.contextmanager
+def top(
+    args: typing.Optional[typing.Sequence[str]] = None,
+    *,
+    context: typing.Optional[rclpy.context.Context] = None,
+    global_: bool = False,
+    **kwargs: typing.Any,
+) -> typing.Iterator[ROSAwareScope]:
+    """
+    Manages a ROS 2 aware scope, handling ROS 2 context lifecycle as well.
+
+    Args:
+        args: optional command-line arguments for context initialization.
+        context: optional context to manage. If none is provided, one will
+        be created. For global scopes, the default context will be used.
+
+    See `ROSAwareScope` documentation for further reference on positional
+    and keyword arguments taken by this function.
+
+    Returns:
+        a context manager.
+    """
+    if context is None and not global_:
+        context = rclpy.context.Context()
+    rclpy.init(args=args, context=context)
+    try:
+        with ROSAwareScope(global_=global_, context=context, **kwargs) as scope:
+            yield scope
+    finally:
+        rclpy.try_shutdown(context=context)
+
+
+def current() -> typing.Optional[ROSAwareScope]:
+    """Gets the current ROS 2 aware scope, if any."""
+    return getattr(ROSAwareScope.local, "top", ROSAwareScope.global_)
+
+
+def node() -> typing.Optional[rclpy.node.Node]:
+    """Gets the node of the current ROS 2 aware scope, if any."""
+    scope = current()
+    if scope is None:
+        return None
+    return scope.node
+
+
+def executor() -> typing.Optional[rclpy.executors.Executor]:
+    """Gets the executor of the current ROS 2 aware scope, if any."""
+    scope = current()
+    if scope is None:
+        return None
+    return scope.executor
+
+
+def load(factory: AnyEntityFactoryCallable, *args: typing.Any, **kwargs: typing.Any) -> AnyEntity:
+    """
+    Loads a ROS 2 node (or a collection thereof) within the current ROS 2 aware scope.
+
+    See `ROSAwareScope.load` documentation for further reference on positional and keyword
+    arguments taken by this function.
+
+    Raises:
+        RuntimeError: if called outside scope.
+    """
+    scope = current()
+    if scope is None:
+        raise RuntimeError("not in any scope")
+    return scope.load(factory, *args, **kwargs)
+
+
+def unload(loaded: AnyEntity) -> None:
+    """
+    Unloads a ROS 2 node (or a collection thereof) from the current ROS 2 aware scope.
+
+    See `ROSAwareScope.unload` documentation for further reference on positional and
+    keyword arguments taken by this function.
+
+    Raises:
+        RuntimeError: if called outside scope.
+    """
+    scope = current()
+    if scope is None:
+        raise RuntimeError("not in any scope")
+    scope.unload(loaded)
+
+
+def managed(
+    factory: AnyEntityFactoryCallable, *args: typing.Any, **kwargs: typing.Any
+) -> typing.ContextManager[AnyEntity]:
+    """
+    Manages a ROS 2 node (or a collection thereof) within the current ROS 2 aware scope.
+
+    See `ROSAwareScope.managed` documentation for further reference on positional and
+    keyword arguments taken by this function.
+
+    Raises:
+        RuntimeError: if called outside scope.
+    """
+    scope = current()
+    if scope is None:
+        raise RuntimeError("not in any scope")
+    return scope.managed(factory, *args, **kwargs)
+
+
+def spin(factory: typing.Optional[AnyEntityFactoryCallable] = None, *args: typing.Any, **kwargs: typing.Any) -> None:
+    """
+    Spins current ROS 2 aware scope executor (and all the ROS 2 nodes in it).
+
+    Optionally, manages a ROS 2 node (or a collection thereof) for as long as it spins.
+
+    See `ROSAwareScope.spin` documentation for further reference on positional and keyword
+    arguments taken by this function.
+
+    Raises:
+        RuntimeError: if called outside scope.
+    """
+    scope = current()
+    if scope is None:
+        raise RuntimeError("not in any scope")
+    if factory is not None:
+        scope.spin(factory, *args, **kwargs)
+    else:
+        scope.spin()

--- a/bdai_ros2_wrappers/examples/background_action_example.py
+++ b/bdai_ros2_wrappers/examples/background_action_example.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+
+"""
+An example of a ROS 2 aware executable using process-wide machinery.
+
+Run with:
+
+```sh
+python3 examples/background_action_example.py
+```
+
+And follow the instructions on screen.
+"""
+
+import sys
+from typing import Any
+
+from example_interfaces.action import Fibonacci
+from rclpy.action.client import ActionClient
+from rclpy.action.server import ActionServer, ServerGoalHandle
+
+import bdai_ros2_wrappers.process as ros_process
+from bdai_ros2_wrappers.node import Node
+
+
+class MinimalActionServer(Node):
+    """A minimal ROS 2 node serving an example_interfaces.action.Fibonacci action."""
+
+    def __init__(self, node_name: str = "minimal_action_server", **kwargs: Any) -> None:
+        super().__init__(node_name, **kwargs)
+        self._action_server = ActionServer(self, Fibonacci, "compute_fibonacci_sequence", self.execute_callback)
+
+    def execute_callback(self, goal_handle: ServerGoalHandle) -> Fibonacci.Result:
+        sequence = [0, 1]
+
+        for i in range(1, goal_handle.request.order):
+            sequence.append(sequence[i] + sequence[i - 1])
+            feedback = Fibonacci.Feedback()
+            feedback.sequence = sequence
+            goal_handle.publish_feedback(feedback)
+        goal_handle.succeed()
+
+        result = Fibonacci.Result()
+        result.sequence = sequence
+        return result
+
+
+@ros_process.main()
+def main() -> None:
+    main.load(MinimalActionServer)
+
+    action_client = ActionClient(main.node, Fibonacci, "compute_fibonacci_sequence")
+    assert action_client.wait_for_server(timeout_sec=5)
+
+    while True:
+        line = input("Please provide a Fibonacci sequence order (or press Enter to exit): ")
+        if not line:
+            break
+        try:
+            order = int(line)
+        except ValueError:
+            print(f"    Hmm, '{line}' is not a number", file=sys.stderr)
+            continue
+        result = action_client.send_goal(Fibonacci.Goal(order=order))
+        print("Computed Fibonacci sequence: ", list(result.result.sequence))
+    print("Bye bye!")
+
+
+if __name__ == "__main__":
+    main()

--- a/bdai_ros2_wrappers/examples/talker_example.py
+++ b/bdai_ros2_wrappers/examples/talker_example.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+
+"""
+An example of a ROS 2 single node process using process-wide machinery.
+
+Run with:
+
+```sh
+python3 examples/talker_example.py chit chat
+```
+
+You can speed up publication with:
+
+```sh
+python3 examples/talker_example.py chit chat --ros-args -p rate:=5.0  # Hz
+```
+"""
+
+import itertools
+import typing
+
+import bdai_ros2_wrappers.process as ros_process
+from bdai_ros2_wrappers.node import Node
+
+
+class TalkerNode(Node):
+    """A node that logs the same phrase periodically."""
+
+    def __init__(self, phrase: str, **kwargs: typing.Any) -> None:
+        super().__init__("talker", **kwargs)
+        self.phrase = phrase
+        self.counter = itertools.count(start=1)
+        rate = self.declare_parameter("rate", 1.0).value
+        self.timer = self.create_timer(1 / rate, self.callback)
+
+    def callback(self) -> None:
+        self.get_logger().info(f"{self.phrase} (#{next(self.counter)})")
+
+
+@ros_process.main(prebaked=False)
+def main(args: typing.Sequence[str]) -> None:
+    ros_process.spin(TalkerNode, " ".join(args[1:]))
+
+
+if __name__ == "__main__":
+    main()

--- a/bdai_ros2_wrappers/examples/talker_listener_example.py
+++ b/bdai_ros2_wrappers/examples/talker_listener_example.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+
+"""
+An example of a ROS 2 multi-node process using process-wide machinery.
+
+Run with:
+
+```sh
+python3 examples/talker_listener_example.py
+```
+"""
+
+import itertools
+import typing
+
+import std_msgs.msg
+
+import bdai_ros2_wrappers.process as ros_process
+from bdai_ros2_wrappers.node import Node
+
+
+class TalkerNode(Node):
+    """A node that publishes a phrase periodically."""
+
+    def __init__(self, **kwargs: typing.Any) -> None:
+        super().__init__("talker", **kwargs)
+        self.counter = itertools.count(start=1)
+        self.pub = self.create_publisher(std_msgs.msg.String, "chat", 1)
+        rate = self.declare_parameter("rate", 1.0).value
+        self.timer = self.create_timer(1 / rate, self.callback)
+
+    def callback(self) -> None:
+        message = std_msgs.msg.String(data=f"Hi there, from {self.get_name()} (#{next(self.counter)})")
+        self.pub.publish(message)
+
+
+class ListenerNode(Node):
+    """A node that subscribes to chattering."""
+
+    def __init__(self, **kwargs: typing.Any) -> None:
+        super().__init__("listener", **kwargs)
+        self.sub = self.create_subscription(std_msgs.msg.String, "chat", self.callback, 1)
+
+    def callback(self, message: std_msgs.msg.String) -> None:
+        self.get_logger().info(message.data)
+
+
+def graph(**kwargs: typing.Any) -> typing.Iterable[Node]:
+    return [TalkerNode(**kwargs), ListenerNode(**kwargs)]
+
+
+@ros_process.main(prebaked=False, namespace=True)
+def main() -> None:
+    ros_process.spin(graph)
+
+
+if __name__ == "__main__":
+    main()

--- a/bdai_ros2_wrappers/examples/tf_cli_example.py
+++ b/bdai_ros2_wrappers/examples/tf_cli_example.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+
+"""
+An example of a ROS 2 aware command using process-wide machinery.
+
+Run with:
+
+```sh
+python3 examples/tf_cli_example.py
+```
+
+And follow the instructions on screen.
+"""
+
+import argparse
+import math
+import time
+from typing import Any, Iterable, List, Optional
+
+from geometry_msgs.msg import TransformStamped
+from rclpy.executors import SingleThreadedExecutor
+from tf2_ros.transform_broadcaster import TransformBroadcaster
+
+import bdai_ros2_wrappers.process as ros_process
+from bdai_ros2_wrappers.executors import background
+from bdai_ros2_wrappers.node import Node
+from bdai_ros2_wrappers.tf_listener_wrapper import TFListenerWrapper
+from bdai_ros2_wrappers.utilities import namespace_with
+
+
+class TFBroadcasterNode(Node):
+    def __init__(self, tf_prefix: Optional[str] = None, **kwargs: Any) -> None:
+        super().__init__("tf_broadcaster", **kwargs)
+        self.tf_broadcaster = TransformBroadcaster(self)
+        self.transforms: List[TransformStamped] = []
+        tree = [("world", "odom", 0.0, 1.0, math.degrees(90.0)), ("odom", "robot", 3.0, -0.5, math.degrees(-30.0))]
+        for parent_frame, child_frame, x, y, theta in tree:
+            transform = TransformStamped()
+            transform.header.frame_id = namespace_with(tf_prefix, parent_frame)
+            transform.child_frame_id = namespace_with(tf_prefix, child_frame)
+            transform.transform.translation.x = x
+            transform.transform.translation.y = y
+            transform.transform.translation.z = 0.0
+            transform.transform.rotation.x = 0.0
+            transform.transform.rotation.y = 0.0
+            transform.transform.rotation.z = math.sin(theta / 2)
+            transform.transform.rotation.w = math.cos(theta / 2)
+            self.transforms.append(transform)
+        self.timer = self.create_timer(1.0, self.callback)
+        self.callback()  # do not wait
+
+    def callback(self) -> None:
+        stamp = self.get_clock().now().to_msg()
+        for transform in self.transforms:
+            transform.header.stamp = stamp
+        self.tf_broadcaster.sendTransform(self.transforms)
+
+
+def cli() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--tf-prefix", type=str, default=None)
+    parser.add_argument("-c", "--cache-time", type=float, default=None)
+    parser.add_argument("-b", "--buffer-time", type=float, default=3.0)
+    return parser
+
+
+def graph(args: argparse.Namespace, **kwargs: Any) -> Iterable[Node]:
+    return [TFBroadcasterNode(args.tf_prefix, **kwargs), Node("tf_prompt", **kwargs)]
+
+
+def run(args: argparse.Namespace) -> None:
+    tf_listener = TFListenerWrapper(cache_time_s=args.cache_time)
+    print("Buffering transforms...")
+    time.sleep(args.buffer_time)
+    print(tf_listener.buffer.all_frames_as_string())
+    while True:
+        target_frame = input("Please provide target frame (or press Enter to exit): ")
+        if not target_frame:
+            break
+        source_frame = input("Please provide source frame (or press Enter to reuse): ")
+        if not source_frame:
+            source_frame = target_frame
+        target_frame = namespace_with(args.tf_prefix, target_frame)
+        source_frame = namespace_with(args.tf_prefix, source_frame)
+        transform = tf_listener.lookup_a_tform_b(target_frame, source_frame, wait_for_frames=True)
+        t = transform.transform.translation
+        q = transform.transform.rotation
+        print(f"Transform {target_frame} -> {source_frame}")
+        print(f"  Translation: [x: {t.x}, y: {t.y}, z: {t.z}]")
+        print(f"  Rotation: [x: {q.x}, y: {q.y}, z: {q.z}, w: {q.w}]")
+        print("---")
+    print("Bye bye!")
+
+
+@ros_process.main(cli(), prebaked=False)
+def main(args: argparse.Namespace) -> None:
+    with background(SingleThreadedExecutor()) as main.executor:
+        with ros_process.managed(graph, args) as (_, main.node):
+            run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/bdai_ros2_wrappers/test/conftest.py
+++ b/bdai_ros2_wrappers/test/conftest.py
@@ -1,0 +1,21 @@
+#  Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+from typing import Iterable
+
+import pytest
+
+import bdai_ros2_wrappers.scope as scope
+from bdai_ros2_wrappers.scope import ROSAwareScope
+
+
+@pytest.fixture(scope="function")
+def ros() -> Iterable[ROSAwareScope]:
+    with scope.top(global_=True, namespace="fixture") as top:
+        yield top
+
+
+@pytest.fixture(scope="function")
+def verbose_ros() -> Iterable[ROSAwareScope]:
+    args = ["--ros-args", "--enable-rosout-logs"]
+    with scope.top(args, global_=True, namespace="fixture") as top:
+        yield top

--- a/bdai_ros2_wrappers/test/test_logging.py
+++ b/bdai_ros2_wrappers/test/test_logging.py
@@ -1,50 +1,16 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
 import logging
-from typing import Generator, Optional
+from typing import Optional
 
-import pytest
-import rclpy
 from rcl_interfaces.msg import Log
-from rclpy.context import Context
-from rclpy.executors import Executor, SingleThreadedExecutor
-from rclpy.node import Node
 from rclpy.task import Future
 
+from bdai_ros2_wrappers.futures import wait_for_future
 from bdai_ros2_wrappers.logging import logs_to_ros
+from bdai_ros2_wrappers.scope import ROSAwareScope
 
 
-@pytest.fixture(autouse=True)
-def ros_context() -> Generator[Context, None, None]:
-    context = Context()
-    args = ["--ros-args", "--enable-rosout-logs"]
-    rclpy.init(context=context, args=args)
-    try:
-        yield context
-    finally:
-        context.try_shutdown()
-
-
-@pytest.fixture
-def ros_node(ros_context: Context) -> Generator[Node, None, None]:
-    node = rclpy.create_node("test_node", context=ros_context)
-    try:
-        yield node
-    finally:
-        node.destroy_node()
-
-
-@pytest.fixture
-def ros_executor(ros_context: Context, ros_node: Node) -> Generator[Executor, None, None]:
-    executor = SingleThreadedExecutor(context=ros_context)
-    executor.add_node(ros_node)
-    try:
-        yield executor
-    finally:
-        executor.remove_node(ros_node)
-        executor.shutdown()
-
-
-def test_log_forwarding(ros_node: Node, ros_executor: Executor) -> None:
+def test_log_forwarding(verbose_ros: ROSAwareScope) -> None:
     future: Optional[Future] = None
 
     def callback(message: Log) -> None:
@@ -52,18 +18,19 @@ def test_log_forwarding(ros_node: Node, ros_executor: Executor) -> None:
         if future and not future.done():
             future.set_result(message)
 
-    ros_node.create_subscription(Log, "/rosout", callback, 10)
+    assert verbose_ros.node is not None
+    verbose_ros.node.create_subscription(Log, "/rosout", callback, 10)
 
     future = Future()
-    with logs_to_ros(ros_node):
+    with logs_to_ros(verbose_ros.node):
         logger = logging.getLogger("my_logger")
         logger.propagate = True  # ensure propagation is enabled
         logger.info("test")
 
-    ros_executor.spin_until_future_complete(future, timeout_sec=10)
+    assert wait_for_future(future, timeout_sec=10)
     assert future.done()
     log = future.result()
     # NOTE(hidmic) why are log levels of bytestring type !?
     assert log.level == int.from_bytes(Log.INFO, byteorder="little")
-    assert log.name == ros_node.get_logger().name
+    assert log.name == verbose_ros.node.get_logger().name
     assert log.msg == "(logging.my_logger) test"

--- a/bdai_ros2_wrappers/test/test_process.py
+++ b/bdai_ros2_wrappers/test/test_process.py
@@ -9,7 +9,7 @@ import bdai_ros2_wrappers.process as process
 def test_process_wrapping() -> None:
     """Asserts that the process bound node is made available."""
 
-    @process.main(name="test_process")
+    @process.main()
     def main() -> int:
         def dummy_server_callback(_: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
             response.success = True
@@ -33,14 +33,14 @@ def test_command_wrapping() -> None:
 
     def cli() -> argparse.ArgumentParser:
         parser = argparse.ArgumentParser("test_command")
-        parser.add_argument("-n", "--namespace", default="/")
-        parser.set_defaults(node_args=lambda args: dict(namespace=args.namespace))
+        parser.add_argument("robot")
         return parser
 
     @process.main(cli())
     def main(args: argparse.Namespace) -> int:
-        assert main.node.get_name() == "test_command"
-        assert main.node.get_namespace() == "/foo"
+        assert main.node is not None
+        assert main.node.get_fully_qualified_name() == "/test_command/node"
+        assert args.robot == "spot"
         return 0
 
-    assert main(["test_command", "-n", "/foo"]) == 0
+    assert main(["test_command", "spot"]) == 0

--- a/bdai_ros2_wrappers/test/test_service_handle.py
+++ b/bdai_ros2_wrappers/test/test_service_handle.py
@@ -1,25 +1,13 @@
 #  Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 import inspect
-from typing import Iterable, Optional, Tuple
+from typing import Optional, Tuple
 
-import pytest
-import rclpy
 from rclpy.client import Client
 from std_srvs.srv import Empty, SetBool, Trigger
 
-from bdai_ros2_wrappers.process import ROSAwareScope
+from bdai_ros2_wrappers.scope import ROSAwareScope
 from bdai_ros2_wrappers.service_handle import ServiceHandle
 from bdai_ros2_wrappers.type_hints import SrvTypeRequest, SrvTypeResponse
-
-
-@pytest.fixture
-def ros() -> Iterable[ROSAwareScope]:
-    rclpy.init()
-    try:
-        with ROSAwareScope("fixture") as scope:
-            yield scope
-    finally:
-        rclpy.try_shutdown()
 
 
 def do_request(
@@ -54,6 +42,7 @@ def test_successful_trigger(ros: ROSAwareScope) -> None:
         result.message = "foo"
         return result
 
+    assert ros.node is not None
     ros.node.create_service(Trigger, "trigger_service", callback)
     client = ros.node.create_client(Trigger, "trigger_service")
     ok, result = do_request(client, Trigger.Request())
@@ -73,6 +62,7 @@ def test_failed_trigger(ros: ROSAwareScope) -> None:
         result.message = "bar"
         return result
 
+    assert ros.node is not None
     ros.node.create_service(Trigger, "trigger_service", callback)
     client = ros.node.create_client(Trigger, "trigger_service")
 
@@ -97,6 +87,7 @@ def setbool_service_callback(req: SrvTypeRequest, resp: SrvTypeResponse) -> SrvT
 
 def test_successful_set_bool(ros: ROSAwareScope) -> None:
     """Request data passes a true value. Should return a success condition with the message foo."""
+    assert ros.node is not None
     ros.node.create_service(SetBool, "setbool_service", setbool_service_callback)
     client = ros.node.create_client(SetBool, "setbool_service")
     ok, result = do_request(client, SetBool.Request(data=True))
@@ -109,6 +100,7 @@ def test_successful_set_bool(ros: ROSAwareScope) -> None:
 
 def test_failed_set_bool(ros: ROSAwareScope) -> None:
     """Request data passes a false value. Should return a failure condition with the message bar."""
+    assert ros.node is not None
     ros.node.create_service(SetBool, "setbool_service", setbool_service_callback)
     client = ros.node.create_client(SetBool, "setbool_service")
     ok, result = do_request(client, SetBool.Request(data=False))
@@ -125,6 +117,7 @@ def test_warning(ros: ROSAwareScope) -> None:
     def callback(req: SrvTypeRequest, resp: SrvTypeResponse) -> SrvTypeResponse:
         return Empty.Response()
 
+    assert ros.node is not None
     ros.node.create_service(Empty, "empty_service", callback)
     client = ros.node.create_client(Empty, "empty_service")
     ok, result = do_request(client, Empty.Request())

--- a/bdai_ros2_wrappers/test/test_single_goal_action_server.py
+++ b/bdai_ros2_wrappers/test/test_single_goal_action_server.py
@@ -1,25 +1,12 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
 import array
-from typing import Iterable
 
-import pytest
-import rclpy
 from action_tutorials_interfaces.action import Fibonacci
 from rclpy.action.server import ServerGoalHandle
 
 from bdai_ros2_wrappers.action_client import ActionClientWrapper
 from bdai_ros2_wrappers.process import ROSAwareScope
 from bdai_ros2_wrappers.single_goal_action_server import SingleGoalActionServer
-
-
-@pytest.fixture
-def ros() -> Iterable[ROSAwareScope]:
-    rclpy.init()
-    try:
-        with ROSAwareScope("fixture") as scope:
-            yield scope
-    finally:
-        rclpy.try_shutdown()
 
 
 def test_single_goal_action_server(ros: ROSAwareScope) -> None:
@@ -41,6 +28,7 @@ def test_single_goal_action_server(ros: ROSAwareScope) -> None:
         result.sequence = sequence
         return result
 
+    assert ros.node is not None
     SingleGoalActionServer(ros.node, Fibonacci, "fibonacci", execute_callback)
     action_client = ActionClientWrapper(Fibonacci, "fibonacci", ros.node)
 

--- a/bdai_ros2_wrappers/test/test_subscription.py
+++ b/bdai_ros2_wrappers/test/test_subscription.py
@@ -1,27 +1,15 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
 import time
-import typing
 
-import pytest
-import rclpy
 from std_msgs.msg import Int8
 
-from bdai_ros2_wrappers.process import ROSAwareScope
+from bdai_ros2_wrappers.scope import ROSAwareScope
 from bdai_ros2_wrappers.subscription import wait_for_message
-
-
-@pytest.fixture
-def ros() -> typing.Iterable[ROSAwareScope]:
-    rclpy.init()
-    try:
-        with ROSAwareScope("fixture") as scope:
-            yield scope
-    finally:
-        rclpy.try_shutdown()
 
 
 def test_wait_for_message(ros: ROSAwareScope) -> None:
     """Asserts that wait for message works as expected."""
+    assert ros.node is not None
     pub = ros.node.create_publisher(Int8, "test", 1)
     assert not wait_for_message(Int8, "test", node=ros.node, timeout_sec=0.5)
 
@@ -29,6 +17,7 @@ def test_wait_for_message(ros: ROSAwareScope) -> None:
         time.sleep(1.0)
         pub.publish(Int8(data=1))
 
+    assert ros.executor is not None
     ros.executor.create_task(deferred_publish)
     message = wait_for_message(Int8, "test", node=ros.node, timeout_sec=10.0)
     assert message is not None

--- a/bdai_ros2_wrappers/test/test_utilities.py
+++ b/bdai_ros2_wrappers/test/test_utilities.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-from bdai_ros2_wrappers.utilities import either_or, namespace
+from bdai_ros2_wrappers.utilities import either_or, namespace_with
 
 
 def test_either_or() -> None:
@@ -13,8 +13,8 @@ def test_either_or() -> None:
     assert either_or(data, "getter", False)
 
 
-def test_namespace() -> None:
-    assert namespace(None, "foo") == "foo"
-    assert namespace("", "foo") == "foo"
-    assert namespace("/", "foo") == "/foo"
-    assert namespace("foo", "bar") == "foo/bar"
+def test_namespace_with() -> None:
+    assert namespace_with(None, "foo") == "foo"
+    assert namespace_with("", "foo") == "foo"
+    assert namespace_with("/", "foo") == "/foo"
+    assert namespace_with("foo", "bar") == "foo/bar"


### PR DESCRIPTION
Also adds examples of use and additional tests. This PR is the result of migrating more packages downstream, which brought new use cases I had missed the first time I crafted the process-wide machinery.