### PR TITLE
Re-implement StaticTransformBroadcaster to persist transforms

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/static_transform_broadcaster.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/static_transform_broadcaster.py
@@ -30,7 +30,7 @@ class StaticTransformBroadcaster:
     def sendTransform(self, transform: Union[TransformStamped, Iterable[TransformStamped]]) -> None:
         try:
             transforms = list(transform)
-        except TypeError:
+        except TypeError:  # in which case, transform is not iterable
             transforms = [cast(TransformStamped, transform)]
         self._net_transforms.update({tf.child_frame_id: tf for tf in transforms})
         self._pub.publish(TFMessage(transforms=list(self._net_transforms.values())))

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/static_transform_broadcaster.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/static_transform_broadcaster.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+from typing import Dict, Iterable, Optional, Union, cast
+
+from geometry_msgs.msg import TransformStamped
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile
+from tf2_msgs.msg import TFMessage
+
+
+class StaticTransformBroadcaster:
+    """
+    A modified :class:`tf2_ros.StaticTransformBroadcaster` that stores transforms
+    sent through it, matching ``rclcpp::StaticTransformBroadcaster`` behavior.
+    """
+
+    DEFAULT_QOS = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST)
+
+    def __init__(self, node: Node, qos: Optional[Union[QoSProfile, int]] = None) -> None:
+        """
+        Constructor.
+
+        :param node: The ROS2 node.
+        :param qos: A QoSProfile or a history depth to apply to the publisher.
+        """
+        if qos is None:
+            qos = StaticTransformBroadcaster.DEFAULT_QOS
+        self._net_transforms: Dict[str, TransformStamped] = {}
+        self._pub = node.create_publisher(TFMessage, "/tf_static", qos)
+
+    def sendTransform(self, transform: Union[TransformStamped, Iterable[TransformStamped]]) -> None:
+        try:
+            transforms = list(transform)
+        except TypeError:
+            transforms = [cast(TransformStamped, transform)]
+        self._net_transforms.update({tf.child_frame_id: tf for tf in transforms})
+        self._pub.publish(TFMessage(transforms=list(self._net_transforms.values())))

--- a/bdai_ros2_wrappers/test/test_static_transform_broadcaster.py
+++ b/bdai_ros2_wrappers/test/test_static_transform_broadcaster.py
@@ -35,8 +35,6 @@ def test_static_tf_burst(ros: ROSAwareScope) -> None:
     head_to_camera_transform.transform.rotation.z = 1.0
     tf_broadcaster.sendTransform([body_to_head_transform, head_to_camera_transform])
 
-    ros.node.get_clock().now()
-
     world_to_fiducial_a_transform = TransformStamped()
     world_to_fiducial_a_transform.header.stamp = stamp
     world_to_fiducial_a_transform.header.frame_id = "world"

--- a/bdai_ros2_wrappers/test/test_static_transform_broadcaster.py
+++ b/bdai_ros2_wrappers/test/test_static_transform_broadcaster.py
@@ -50,7 +50,7 @@ def test_static_tf_burst(ros: ROSAwareScope) -> None:
     tf_broadcaster.sendTransform([world_to_fiducial_a_transform, footprint_to_body_transform])
 
     tf_listener = TFListenerWrapper(ros.node)
-    transform = tf_listener.lookup_a_tform_b("footprint", "camera", timeout=2.0, wait_for_frames=True)
+    transform = tf_listener.lookup_a_tform_b("footprint", "camera", timeout_sec=2.0, wait_for_frames=True)
     assert transform.transform.rotation.w == 1.0
-    transform = tf_listener.lookup_a_tform_b("world", "fiducial_a", timeout=2.0, wait_for_frames=True)
+    transform = tf_listener.lookup_a_tform_b("world", "fiducial_a", timeout_sec=2.0, wait_for_frames=True)
     assert transform.transform.translation.x == 1.0

--- a/bdai_ros2_wrappers/test/test_static_transform_broadcaster.py
+++ b/bdai_ros2_wrappers/test/test_static_transform_broadcaster.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
+
+from geometry_msgs.msg import TransformStamped
+
+from bdai_ros2_wrappers.scope import ROSAwareScope
+from bdai_ros2_wrappers.static_transform_broadcaster import StaticTransformBroadcaster
+from bdai_ros2_wrappers.tf_listener_wrapper import TFListenerWrapper
+
+
+def test_static_tf_burst(ros: ROSAwareScope) -> None:
+    """Asserts that all static transforms broadcasted in sequence are kept."""
+    assert ros.node is not None
+
+    tf_broadcaster = StaticTransformBroadcaster(ros.node)
+
+    stamp = ros.node.get_clock().now().to_msg()
+
+    world_to_fiducial_a_transform = TransformStamped()
+    world_to_fiducial_a_transform.header.stamp = stamp
+    world_to_fiducial_a_transform.header.frame_id = "world"
+    world_to_fiducial_a_transform.child_frame_id = "fiducial_a"
+    world_to_fiducial_a_transform.transform.rotation.w = 1.0
+    tf_broadcaster.sendTransform(world_to_fiducial_a_transform)
+
+    body_to_head_transform = TransformStamped()
+    body_to_head_transform.header.stamp = stamp
+    body_to_head_transform.header.frame_id = "body"
+    body_to_head_transform.child_frame_id = "head"
+    body_to_head_transform.transform.rotation.z = -1.0
+
+    head_to_camera_transform = TransformStamped()
+    head_to_camera_transform.header.stamp = stamp
+    head_to_camera_transform.header.frame_id = "head"
+    head_to_camera_transform.child_frame_id = "camera"
+    head_to_camera_transform.transform.rotation.z = 1.0
+    tf_broadcaster.sendTransform([body_to_head_transform, head_to_camera_transform])
+
+    ros.node.get_clock().now()
+
+    world_to_fiducial_a_transform = TransformStamped()
+    world_to_fiducial_a_transform.header.stamp = stamp
+    world_to_fiducial_a_transform.header.frame_id = "world"
+    world_to_fiducial_a_transform.child_frame_id = "fiducial_a"
+    world_to_fiducial_a_transform.transform.translation.x = 1.0
+    world_to_fiducial_a_transform.transform.rotation.w = 1.0
+
+    footprint_to_body_transform = TransformStamped()
+    footprint_to_body_transform.header.stamp = stamp
+    footprint_to_body_transform.header.frame_id = "footprint"
+    footprint_to_body_transform.child_frame_id = "body"
+    footprint_to_body_transform.transform.rotation.w = 1.0
+    tf_broadcaster.sendTransform([world_to_fiducial_a_transform, footprint_to_body_transform])
+
+    tf_listener = TFListenerWrapper(ros.node)
+    transform = tf_listener.lookup_a_tform_b("footprint", "camera", timeout=2.0, wait_for_frames=True)
+    assert transform.transform.rotation.w == 1.0
+    transform = tf_listener.lookup_a_tform_b("world", "fiducial_a", timeout=2.0, wait_for_frames=True)
+    assert transform.transform.translation.x == 1.0


### PR DESCRIPTION
This PR re-implements `tf2_ros.StaticTransformBroadcaster` to persist transforms, like its C++ equivalent already does.