### PR TITLE
Fix image names in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
-  IMAGE_NAME: bdaiinstitute/ros_utilties_jammy_humble
+  IMAGE_NAME: bdaiinstitute/ros_utilities_jammy_humble
 
 defaults:
   run:

--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -7,7 +7,7 @@ on:
 env:
   ORG_NAME: bdaiinstitute
   # github.repository as <account>/<repo>
-  IMAGE_NAME: bdaiinstitute/ros_utilties_jammy_humble
+  IMAGE_NAME: ros_utilities_jammy_humble
 
 jobs:
   clean-ghcr:


### PR DESCRIPTION
Follow-up to #48. What `snok/container-retention-policy@v2` refers to as "image-names" is actually "package-names" :roll_eyes: Third's the charm.