### PR TITLE
Avoid rosidl linters in proto2ros vendoring

### DIFF
--- a/proto2ros/cmake/proto2ros_vendor_package.cmake
+++ b/proto2ros/cmake/proto2ros_vendor_package.cmake
@@ -38,15 +38,9 @@ macro(proto2ros_vendor_package target)
     ${proto2ros_generate_OPTIONS}
   )
 
-  set(rosidl_generate_interfaces_OPTIONS)
-  if(NOT ARG_NO_LINT)
-    list(APPEND rosidl_generate_interfaces_OPTIONS ADD_LINTER_TESTS)
-  endif()
-
   rosidl_generate_interfaces(
     ${target} ${ros_messages}
     DEPENDENCIES ${ARG_ROS_DEPENDENCIES} builtin_interfaces proto2ros
-    ${rosidl_generate_interfaces_OPTIONS}
   )
   add_dependencies(${target} ${target}_messages_gen)
 


### PR DESCRIPTION
Precisely what the title says. Having these in place adds little value and makes `bosdyn_msgs*` packages' tests take ages to run.