### PR TITLE
Fix any expansions in proto2ros

### DIFF
--- a/proto2ros/proto2ros/conversions/basic.py
+++ b/proto2ros/proto2ros/conversions/basic.py
@@ -26,7 +26,7 @@ def convert_proto2ros_any_proto_message_to_some_proto(ros_msg: proto2ros.msg.Any
         ValueError: if the given ROS message cannot be unpacked onto the given Protobuf message.
     """
     proto_msg.Clear()
-    wrapper = google.protobuf.Any()
+    wrapper = google.protobuf.any_pb2.Any()
     wrapper.type_url = ros_msg.type_url
     wrapper.value = ros_msg.value.tobytes()
     if not wrapper.Unpack(proto_msg):
@@ -36,11 +36,16 @@ def convert_proto2ros_any_proto_message_to_some_proto(ros_msg: proto2ros.msg.Any
 @convert.register(object, proto2ros.msg.AnyProto)
 def convert_some_proto_to_proto2ros_any_proto_message(proto_msg: Any, ros_msg: proto2ros.msg.AnyProto) -> None:
     """Packs any Protobuf message into a proto2ros/AnyProto ROS message."""
-    wrapper = google.protobuf.Any()
+    wrapper = google.protobuf.any_pb2.Any()
     wrapper.Pack(proto_msg)
     ros_msg.type_url = wrapper.type_url
     ros_msg.value = wrapper.value
 
+
+@convert.register(proto2ros.msg.AnyProto, proto2ros.msg.AnyProto)
+def _(proto_msg: proto2ros.msg.AnyProto, ros_msg: proto2ros.msg.AnyProto) -> None:
+    # address multipledispatch ambiguous resolution concerns
+    raise RuntimeError("invalid overload")
 
 @convert.register(proto2ros.msg.AnyProto, google.protobuf.any_pb2.Any)
 def convert_proto2ros_any_proto_message_to_google_protobuf_any_proto(

--- a/proto2ros/proto2ros/conversions/basic.py
+++ b/proto2ros/proto2ros/conversions/basic.py
@@ -47,6 +47,7 @@ def _(proto_msg: proto2ros.msg.AnyProto, ros_msg: proto2ros.msg.AnyProto) -> Non
     # address multipledispatch ambiguous resolution concerns
     raise RuntimeError("invalid overload")
 
+
 @convert.register(proto2ros.msg.AnyProto, google.protobuf.any_pb2.Any)
 def convert_proto2ros_any_proto_message_to_google_protobuf_any_proto(
     ros_msg: proto2ros.msg.AnyProto, proto_msg: google.protobuf.any_pb2.Any

--- a/proto2ros/proto2ros/equivalences.py
+++ b/proto2ros/proto2ros/equivalences.py
@@ -217,9 +217,7 @@ def translate_type(name: str, repeated: bool, config: Configuration) -> Type:
     return Type(ros_type_name)
 
 
-def translate_any_type(
-    any_expansion: Union[Set[str], str], repeated: bool, config: Configuration
-) -> Type:
+def translate_any_type(any_expansion: Union[Set[str], str], repeated: bool, config: Configuration) -> Type:
     """
     Translates a ``google.protobuf.Any`` type to its ROS equivalent given an any expansion.
 
@@ -288,8 +286,7 @@ def translate_field(
             # Annotate field with paired Protobuf and ROS message type names,
             # so that any expansions can be resolved in conversion code.
             field.annotations["type-casts"] = [
-                (proto_type, translate_type_name(f".{proto_type}", config))
-                for proto_type in any_expansion
+                (proto_type, translate_type_name(f".{proto_type}", config)) for proto_type in any_expansion
             ]
         else:
             type_name = f".{any_expansion}"

--- a/proto2ros/proto2ros/output/templates/conversions.py.jinja
+++ b/proto2ros/proto2ros/output/templates/conversions.py.jinja
@@ -86,8 +86,8 @@ typed_field_message = rclpy.serialization.deserialize_message({{ source }}.value
 convert_{{ spec.type | as_ros_base_type | as_python_identifier }}_message_to_{{ spec.annotations["proto-type"] | as_python_identifier }}_proto(typed_field_message, {{ destination }})
     {%- elif spec.annotations.get("type-casted") -%}
         {#- ROS message must be converted and packed for assignment. -#}
-typed_proto_message = {{ proto_type_name | as_pb2_python_type }}()
-convert_{{ spec.type | as_ros_base_type | as_python_idenfier }}_message_to_{{ proto_type_name | as_python_identifier }}_proto({{ source }}, typed_proto_message)
+typed_proto_message = {{ spec.annotations["proto-type"] | as_pb2_python_type }}()
+convert_{{ spec.type | as_ros_base_type | as_python_identifier }}_message_to_{{ spec.annotations["proto-type"] | as_python_identifier }}_proto({{ source }}, typed_proto_message)
 {{ destination }}.Pack(typed_proto_message)
     {%- elif spec.annotations.get("type-casts") -%}
         {#- ROS message must be deserialized according to type, then converted, then packed for assignment. -#}
@@ -192,17 +192,17 @@ convert_{{ spec.annotations["proto-type"] | as_python_identifier }}_proto_to_{{ 
 {{ destination }}.type_name = "{{ spec.type | as_ros_base_type }}"
     {%- elif spec.annotations.get("type-casted") -%}
         {#- Protobuf message must be unpacked for conversion. -#}
-typed_proto_message = {{ field_spec.annotations["proto-type"] | as_pb2_python_type }}()
+typed_proto_message = {{ spec.annotations["proto-type"] | as_pb2_python_type }}()
 {{ source }}.Unpack(typed_proto_message)
 convert_{{ spec.annotations["proto-type"] | as_python_identifier }}_proto_to_{{ spec.type | as_ros_base_type | as_python_identifier }}_message(typed_proto_message, {{ destination }})
     {%- elif spec.annotations.get("type-casts") -%}
         {#- Protobuf message must be unpacked according to type, then converted, then serialized for assignment. -#}
         {%- for proto_type_name, ros_type_name in spec.annotations["type-casts"] -%}
             {%- if loop.first -%}
-if {{ source }}.Is({{ proto_type_name | as_pb2_python_type }}):
-            {%- else -%}
-elif {{ source }}.Is({{ proto_type_name | as_pb2_python_type }}):
-            {%- endif -%}
+if {{ source }}.Is({{ proto_type_name | as_pb2_python_type }}.DESCRIPTOR):
+            {%- else %}
+elif {{ source }}.Is({{ proto_type_name | as_pb2_python_type }}.DESCRIPTOR):
+            {%- endif %}
     typed_proto_message = {{ proto_type_name | as_pb2_python_type }}()
     ok = {{ source }}.Unpack(typed_proto_message)
     assert ok, "Failed to unpack any protobuf, internal error"
@@ -210,9 +210,9 @@ elif {{ source }}.Is({{ proto_type_name | as_pb2_python_type }}):
     convert_{{ proto_type_name | as_python_identifier }}_proto_to_{{ ros_type_name | as_python_identifier }}_message(typed_proto_message, typed_field_message)
     {{ destination }}.value = rclpy.serialization.serialize_message(typed_field_message)
     {{ destination }}.type_name = "{{ ros_type_name }}"
-        {%- endfor -%}
+        {%- endfor %}
 else:
-    raise ValueError("unknown protobuf message type in {{ spec.name }} member: %s" %s {{ source }}.type_url)
+    raise ValueError("unknown protobuf message type in {{ spec.name }} member: %s" % {{ source }}.type_url)
     {%- elif type_spec and type_spec.annotations.get("tagged") -%}
         {#- Handle one-of field case i.e. determine and convert the Protobuf message member that is set. -#}
 match {{ source.rpartition(".")[0] }}.WhichOneof("{{ spec.name }}"):
@@ -238,7 +238,7 @@ convert_{{ spec.annotations["proto-type"] | as_python_identifier }}_proto_to_{{ 
 def convert_{{ spec.base_type | string | as_python_identifier }}_message_to_{{ spec.annotations["proto-type"] | as_python_identifier  }}_proto(
     ros_msg: {{ spec.base_type | string | as_ros_python_type }}, proto_msg: {{ spec.annotations["proto-type"] | as_pb2_python_type }}
 ) -> None:
-    """Converts from {{ spec.base_type }} ROS messages to {{ spec.annotations["proto-type"] }} Protobuf messages."""
+    """Convert from {{ spec.base_type }} ROS messages to {{ spec.annotations["proto-type"] }} Protobuf messages."""
     {%- if spec.fields %}
     proto_msg.Clear()
         {%- for field_spec in spec.fields if field_spec.name != "has_field" %}
@@ -250,10 +250,11 @@ def convert_{{ spec.base_type | string | as_python_identifier }}_message_to_{{ s
             {%- else %}
     {{ ros_to_proto_field_code(source, destination, field_spec) | indent(4) }}
             {%- endif -%}
-        {% endfor %}
+        {%- endfor -%}
     {% else -%}{#- Handle empty message. #}
     pass
-    {% endif %}
+    {%- endif %}
+
 
 convert_{{ spec.base_type | string | as_python_identifier }}_to_proto = \
     convert_{{ spec.base_type | string | as_python_identifier }}_message_to_{{ spec.annotations["proto-type"] | as_python_identifier  }}_proto
@@ -263,7 +264,7 @@ convert_{{ spec.base_type | string | as_python_identifier }}_to_proto = \
 def convert_{{ spec.annotations["proto-type"] | as_python_identifier  }}_proto_to_{{ spec.base_type | string | as_python_identifier }}_message(
     proto_msg: {{ spec.annotations["proto-type"] | as_pb2_python_type }}, ros_msg: {{ spec.base_type | string | as_ros_python_type }}
 ) -> None:
-    """Converts from {{ spec.annotations["proto-type"] }} Protobuf messages to {{ spec.base_type }} ROS messages."""
+    """Convert from {{ spec.annotations["proto-type"] }} Protobuf messages to {{ spec.base_type }} ROS messages."""
     {%- if spec.fields %}
         {%- if spec.annotations["has-optionals"] %}
     ros_msg.has_field = 0
@@ -278,10 +279,11 @@ def convert_{{ spec.annotations["proto-type"] | as_python_identifier  }}_proto_t
             {%- else %}
     {{ proto_to_ros_field_code(source, destination, field_spec) | indent(4) }}
             {%- endif -%}
-        {% endfor %}
+        {%- endfor -%}
     {% else -%}{#- Handle empty message. #}
     pass
-    {% endif %}
+    {%- endif %}
+
 
 convert_proto_to_{{ spec.base_type | string | as_python_identifier }} = \
     convert_{{ spec.annotations["proto-type"] | as_python_identifier  }}_proto_to_{{ spec.base_type | string | as_python_identifier }}_message

--- a/proto2ros_tests/config/overlay.yaml
+++ b/proto2ros_tests/config/overlay.yaml
@@ -1,6 +1,12 @@
+any_expansions:
+  proto2ros_tests.Goal.target: bosdyn.api.SE2Pose
+  proto2ros_tests.Goal.roi: [bosdyn.api.Polygon, bosdyn.api.Circle]
 message_mapping:
   bosdyn.api.Vec3: geometry_msgs/Vector3
   bosdyn.api.Quaternion: geometry_msgs/Quaternion
+  bosdyn.api.SE2Pose: geometry_msgs/Pose
+  bosdyn.api.Polygon: geometry_msgs/Polygon
+  bosdyn.api.Circle: geometry_msgs/Vector3
   bosdyn.api.SE3Pose: geometry_msgs/Pose
   bosdyn.api.SE3Velocity: geometry_msgs/Twist
   bosdyn.api.Wrench: geometry_msgs/Wrench

--- a/proto2ros_tests/proto/test.proto
+++ b/proto2ros_tests/proto/test.proto
@@ -6,6 +6,9 @@ package proto2ros_tests;
 
 option java_outer_classname = "Proto2ROSTests";
 
+import "google/protobuf/any.proto";
+import "google/protobuf/type.proto";
+
 import "bosdyn/api/geometry.proto";
 
 enum Direction {
@@ -194,4 +197,20 @@ message Map {
         bytes grid = 3;
     }
     map<int32, Fragment> submaps = 1;
+}
+
+// Protobuf type query request message.
+message RTTIQueryRequest {
+    google.protobuf.Any msg = 1;
+}
+
+// Protobuf type query result message.
+message RTTIQueryResult {
+    google.protobuf.Type type = 1;
+}
+
+// Generalized goal.
+message Goal {
+    google.protobuf.Any target = 1;
+    google.protobuf.Any roi = 2;
 }

--- a/proto2ros_tests/proto2ros_tests/manual_conversions.py
+++ b/proto2ros_tests/proto2ros_tests/manual_conversions.py
@@ -1,3 +1,5 @@
+import math
+
 import bosdyn.api.geometry_pb2
 import geometry_msgs.msg
 
@@ -43,7 +45,7 @@ def convert_bosdyn_api_quaternion_proto_to_geometry_msgs_quaternion_message(
 
 
 @convert.register(geometry_msgs.msg.Pose, bosdyn.api.geometry_pb2.SE3Pose)
-def convert_geometry_msgs_pose_message_to_bosdyn_api_pose_proto(
+def convert_geometry_msgs_pose_message_to_bosdyn_api_se3_pose_proto(
     ros_msg: geometry_msgs.msg.Pose, proto_msg: bosdyn.api.geometry_pb2.SE3Pose
 ) -> None:
     convert_geometry_msgs_vector3_message_to_bosdyn_api_vec3_proto(ros_msg.position, proto_msg.position)
@@ -51,11 +53,70 @@ def convert_geometry_msgs_pose_message_to_bosdyn_api_pose_proto(
 
 
 @convert.register(bosdyn.api.geometry_pb2.SE3Pose, geometry_msgs.msg.Pose)
-def convert_bosdyn_api_pose_proto_to_geometry_msgs_pose_message(
+def convert_bosdyn_api_se3_pose_proto_to_geometry_msgs_pose_message(
     proto_msg: bosdyn.api.geometry_pb2.SE3Pose, ros_msg: geometry_msgs.msg.Pose
 ) -> None:
     convert_bosdyn_api_vec3_proto_to_geometry_msgs_vector3_message(proto_msg.position, ros_msg.position)
     convert_bosdyn_api_quaternion_proto_to_geometry_msgs_quaternion_message(proto_msg.rotation, ros_msg.orientation)
+
+
+@convert.register(geometry_msgs.msg.Pose, bosdyn.api.geometry_pb2.SE2Pose)
+def convert_geometry_msgs_pose_message_to_bosdyn_api_se2_pose_proto(
+    ros_msg: geometry_msgs.msg.Pose, proto_msg: bosdyn.api.geometry_pb2.SE2Pose
+) -> None:
+    proto_msg.position.x = ros_msg.position.x
+    proto_msg.position.y = ros_msg.position.y
+    proto_msg.angle = 2.0 * math.acos(ros_msg.orientation.w)
+
+
+@convert.register(bosdyn.api.geometry_pb2.SE2Pose, geometry_msgs.msg.Pose)
+def convert_bosdyn_api_se2_pose_proto_to_geometry_msgs_pose_message(
+    proto_msg: bosdyn.api.geometry_pb2.SE2Pose, ros_msg: geometry_msgs.msg.Pose
+) -> None:
+    ros_msg.position.x = proto_msg.position.x
+    ros_msg.position.y = proto_msg.position.y
+    ros_msg.orientation.w = math.cos(proto_msg.angle / 2.0)
+    ros_msg.orientation.z = math.sin(proto_msg.angle / 2.0)
+
+
+@convert.register(geometry_msgs.msg.Polygon, bosdyn.api.geometry_pb2.Polygon)
+def convert_geometry_msgs_polygon_message_to_bosdyn_api_polygon_proto(
+    ros_msg: geometry_msgs.msg.Polygon, proto_msg: bosdyn.api.geometry_pb2.Polygon
+) -> None:
+    proto_msg.Clear()
+    for point in ros_msg.points:
+        vertex = proto_msg.vertexes.add()
+        vertex.x = point.x
+        vertex.y = point.y
+
+
+@convert.register(bosdyn.api.geometry_pb2.Polygon, geometry_msgs.msg.Polygon)
+def convert_bosdyn_api_polygon_proto_to_geometry_msgs_polygon_message(
+    proto_msg: bosdyn.api.geometry_pb2.Polygon, ros_msg: geometry_msgs.msg.Polygon
+) -> None:
+    ros_msg.points = [
+        geometry_msgs.msg.Point32(
+            x=vertex.x, y=vertex.y, z=0.0
+        ) for vertex in proto_msg.vertexes
+    ]
+
+
+@convert.register(geometry_msgs.msg.Vector3, bosdyn.api.geometry_pb2.Circle)
+def convert_geometry_msgs_vector3_message_to_bosdyn_api_circle_proto(
+    ros_msg: geometry_msgs.msg.Vector3, proto_msg: bosdyn.api.geometry_pb2.Circle
+) -> None:
+    proto_msg.center_pt.x = ros_msg.x
+    proto_msg.center_pt.y = ros_msg.y
+    proto_msg.radius = ros_msg.z
+
+
+@convert.register(bosdyn.api.geometry_pb2.Circle, geometry_msgs.msg.Vector3)
+def convert_bosdyn_api_circle_proto_to_geometry_msgs_vector3_message(
+    proto_msg: bosdyn.api.geometry_pb2.Circle, ros_msg: geometry_msgs.msg.Vector3
+) -> None:
+    ros_msg.x = proto_msg.center_pt.x
+    ros_msg.y = proto_msg.center_pt.y
+    ros_msg.z = proto_msg.radius
 
 
 @convert.register(geometry_msgs.msg.Twist, bosdyn.api.geometry_pb2.SE3Velocity)

--- a/proto2ros_tests/proto2ros_tests/manual_conversions.py
+++ b/proto2ros_tests/proto2ros_tests/manual_conversions.py
@@ -94,11 +94,7 @@ def convert_geometry_msgs_polygon_message_to_bosdyn_api_polygon_proto(
 def convert_bosdyn_api_polygon_proto_to_geometry_msgs_polygon_message(
     proto_msg: bosdyn.api.geometry_pb2.Polygon, ros_msg: geometry_msgs.msg.Polygon
 ) -> None:
-    ros_msg.points = [
-        geometry_msgs.msg.Point32(
-            x=vertex.x, y=vertex.y, z=0.0
-        ) for vertex in proto_msg.vertexes
-    ]
+    ros_msg.points = [geometry_msgs.msg.Point32(x=vertex.x, y=vertex.y, z=0.0) for vertex in proto_msg.vertexes]
 
 
 @convert.register(geometry_msgs.msg.Vector3, bosdyn.api.geometry_pb2.Circle)

--- a/proto2ros_tests/test/generated/Goal.msg
+++ b/proto2ros_tests/test/generated/Goal.msg
@@ -1,0 +1,8 @@
+# Generalized goal.
+
+uint8 TARGET_FIELD_SET=1
+uint8 ROI_FIELD_SET=2
+
+geometry_msgs/Pose target
+proto2ros/Any roi
+uint8 has_field 255

--- a/proto2ros_tests/test/generated/RTTIQueryRequest.msg
+++ b/proto2ros_tests/test/generated/RTTIQueryRequest.msg
@@ -1,0 +1,6 @@
+# Protobuf type query request message.
+
+uint8 MSG_FIELD_SET=1
+
+proto2ros/AnyProto msg
+uint8 has_field 255

--- a/proto2ros_tests/test/generated/RTTIQueryResult.msg
+++ b/proto2ros_tests/test/generated/RTTIQueryResult.msg
@@ -1,0 +1,6 @@
+# Protobuf type query result message.
+
+uint8 TYPE_FIELD_SET=1
+
+proto2ros/AnyProto type
+uint8 has_field 255

--- a/proto2ros_tests/test/test_proto2ros.py
+++ b/proto2ros_tests/test/test_proto2ros.py
@@ -5,11 +5,10 @@ import math
 import os
 import pathlib
 
-import google.protobuf.type_pb2
 import bosdyn.api.geometry_pb2
-import test_pb2
-
 import geometry_msgs.msg
+import google.protobuf.type_pb2
+import test_pb2
 
 import proto2ros.msg
 import proto2ros_tests.msg


### PR DESCRIPTION
As I was auditing `bosdyn_msgs*` packages, I came across a few issues in how `google.protobuf.Any` is handled by `proto2ros`. That uncovered a number of issues in how any expansions are implemented, and an omission in `proto2ros_tests`.

This patch addresses all these issues.