### PR TITLE
Preserve empty Protobuf messages upon ROS 2 conversions

### DIFF
--- a/proto2ros/proto2ros/output/templates/conversions.py.jinja
+++ b/proto2ros/proto2ros/output/templates/conversions.py.jinja
@@ -251,7 +251,7 @@ def convert_{{ spec.base_type | string | as_python_identifier }}_message_to_{{ s
             {%- endif -%}
         {%- endfor -%}
     {% else -%}{#- Handle empty message. #}
-    pass
+    proto_msg.SetInParent()
     {%- endif %}
 
 

--- a/proto2ros_tests/proto/test.proto
+++ b/proto2ros_tests/proto/test.proto
@@ -94,9 +94,13 @@ message AnyCommand {
         // Jump height.
         float height = 1;
     }
+    // Sit command.
+    message Sit {}
+
     oneof commands {
         Walk walk = 1;
         Jump jump = 2;
+        Sit sit = 3;
     }
 }
 

--- a/proto2ros_tests/test/generated/AnyCommandOneOfCommands.msg
+++ b/proto2ros_tests/test/generated/AnyCommandOneOfCommands.msg
@@ -2,8 +2,10 @@
 int8 COMMANDS_NOT_SET=0
 int8 COMMANDS_WALK_SET=1
 int8 COMMANDS_JUMP_SET=2
+int8 COMMANDS_SIT_SET=3
 
 proto2ros_tests/AnyCommandWalk walk
 proto2ros_tests/AnyCommandJump jump
+proto2ros_tests/AnyCommandSit sit
 int8 commands_choice  # deprecated
 int8 which

--- a/proto2ros_tests/test/generated/AnyCommandSit.msg
+++ b/proto2ros_tests/test/generated/AnyCommandSit.msg
@@ -1,0 +1,1 @@
+# Sit command.

--- a/proto2ros_tests/test/test_proto2ros.py
+++ b/proto2ros_tests/test/test_proto2ros.py
@@ -78,6 +78,7 @@ def test_one_of_messages() -> None:
     ros_any_command = proto2ros_tests.msg.AnyCommand()
     convert(proto_any_command, ros_any_command)
     walk_set = proto2ros_tests.msg.AnyCommandOneOfCommands.COMMANDS_WALK_SET
+    assert ros_any_command.commands.which == walk_set
     assert ros_any_command.commands.commands_choice == walk_set
     assert ros_any_command.commands.walk.distance == proto_any_command.walk.distance
     assert ros_any_command.commands.walk.speed == proto_any_command.walk.speed
@@ -87,6 +88,21 @@ def test_one_of_messages() -> None:
     assert other_proto_any_command.WhichOneof("commands") == "walk"
     assert other_proto_any_command.walk.distance == proto_any_command.walk.distance
     assert other_proto_any_command.walk.speed == proto_any_command.walk.speed
+
+
+def test_one_of_empty_messages() -> None:
+    proto_any_command = test_pb2.AnyCommand()
+    proto_any_command.sit.SetInParent()
+
+    ros_any_command = proto2ros_tests.msg.AnyCommand()
+    convert(proto_any_command, ros_any_command)
+    sit_set = proto2ros_tests.msg.AnyCommandOneOfCommands.COMMANDS_SIT_SET
+    assert ros_any_command.commands.which == sit_set
+    assert ros_any_command.commands.commands_choice == sit_set
+
+    other_proto_any_command = test_pb2.AnyCommand()
+    convert(ros_any_command, other_proto_any_command)
+    assert other_proto_any_command.WhichOneof("commands") == "sit"
 
 
 def test_messages_with_map_field() -> None:


### PR DESCRIPTION
Another pesky `proto2ros` bug. It turns out that using the presence of empty Protobuf message fields to convey information is a thing. Empty message presence was preserved going from Protobuf to ROS 2 but not on the way back. This patch fixes the issue and adds a regression test.