### PR TITLE
Ensure Python 3.8 compatibility

### DIFF
--- a/bdai_ros2_wrappers/test/test_action.py
+++ b/bdai_ros2_wrappers/test/test_action.py
@@ -84,13 +84,9 @@ def test_successful_asynchronous_action_invocation(ros: ROSAwareScope) -> None:
 
 
 def test_spin_on_succesful_asynchronous_action_invocation() -> None:
-    # Prevent ruff from switching to parenthesized context
-    # managers or it will break Python 3.8 compatibility.
-    # fmt: off
-    with ros_scope.top(global_=True, prebaked=False, namespace="fixture") as ros, \
-        foreground(SingleThreadedExecutor()) as ros.executor, \
-        ros.managed(Node, node_name="test_node") as ros.node:
-    # fmt: on
+    with ros_scope.top(global_=True, prebaked=False, namespace="fixture") as ros, foreground(
+        SingleThreadedExecutor(),
+    ) as ros.executor, ros.managed(Node, node_name="test_node") as ros.node:
         ActionServer(ros.node, Fibonacci, "fibonacci/compute", default_execute_callback)
         compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
         action = compute_fibonacci.asynchronously(Fibonacci.Goal(order=5))

--- a/configs/black.toml
+++ b/configs/black.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ['py310']
+target-version = ['py38']
 include = '\.pyi?$'
 # `extend-exclude` is not honored when `black` is passed a file path explicitly,
 # as is typical when `black` is invoked via `pre-commit`.

--- a/configs/ruff.toml
+++ b/configs/ruff.toml
@@ -38,8 +38,8 @@ line-length = 120
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.10.
-target-version = "py310"
+# Assume Python 3.8.
+target-version = "py38"
 
 [per-file-ignores]
 "__init__.py" = ["F401"]

--- a/proto2ros/proto2ros/output/templates/conversions.py.jinja
+++ b/proto2ros/proto2ros/output/templates/conversions.py.jinja
@@ -91,28 +91,35 @@ convert_{{ spec.type | as_ros_base_type | as_python_identifier }}_message_to_{{ 
 {{ destination }}.Pack(typed_{{ source | python_identifier_name }}_message)
     {%- elif spec.annotations.get("type-casts") -%}
         {#- ROS message must be deserialized according to type, then converted, then packed for assignment. -#}
-match {{ source }}.type_name:
-    {% for proto_type_name, ros_type_name in spec.annotations["type-casts"] -%}
-    case "{{ ros_type_name }}":
-        typed_{{ ros_type_name | as_python_identifier | python_identifier_name }}_message = rclpy.serialization.deserialize_message({{ source }}.value.tobytes(), {{ ros_type_name | as_ros_python_type }})
-        typed_{{ proto_type_name | as_python_identifier | python_identifier_name }}_message = {{ proto_type_name | as_pb2_python_type }}()
-        convert_{{ ros_type_name | as_python_identifier }}_message_to_{{ proto_type_name | as_python_identifier }}_proto(typed_{{ ros_type_name | as_python_identifier | python_identifier_name }}_message, typed_{{ proto_type_name | as_python_identifier | python_identifier_name }}_message)
-        {{ destination }}.Pack(typed_{{ proto_type_name | as_python_identifier | python_identifier_name }}_message)
-    {% endfor -%}
-    case _:
-        raise ValueError("unexpected %s in {{ spec.name }} member:" % ros_msg.{{ spec.name }}.type)
+        {% for proto_type_name, ros_type_name in spec.annotations["type-casts"] -%}
+            {%- if loop.first -%}
+if {{ source }}.type_name == "{{ ros_type_name }}":
+            {%- else %}
+elif {{ source }}.type_name == "{{ ros_type_name }}":
+            {%- endif %}
+    typed_{{ ros_type_name | as_python_identifier | python_identifier_name }}_message = rclpy.serialization.deserialize_message({{ source }}.value.tobytes(), {{ ros_type_name | as_ros_python_type }})
+    typed_{{ proto_type_name | as_python_identifier | python_identifier_name }}_message = {{ proto_type_name | as_pb2_python_type }}()
+    convert_{{ ros_type_name | as_python_identifier }}_message_to_{{ proto_type_name | as_python_identifier }}_proto(typed_{{ ros_type_name | as_python_identifier | python_identifier_name }}_message, typed_{{ proto_type_name | as_python_identifier | python_identifier_name }}_message)
+    {{ destination }}.Pack(typed_{{ proto_type_name | as_python_identifier | python_identifier_name }}_message)
+       {%- endfor %}
+else:
+    raise ValueError("unexpected %s in {{ spec.name }} member:" % ros_msg.{{ spec.name }}.type)
     {%- elif type_spec and type_spec.annotations.get("tagged") -%}
         {#- Handle one-of field case i.e. determine and convert the ROS message member that is set. -#}
         {%- set tag_field_spec = type_spec.annotations["tag"] -%}
-match {{ source }}.{{ tag_field_spec.name }} or {{ source }}.{{ tag_field_spec.annotations["alias"] }}:
+which = {{ source }}.{{ tag_field_spec.name }} or {{ source }}.{{ tag_field_spec.annotations["alias"] }}
         {%- for tag_spec, member_spec in type_spec.annotations["tagged"] %}
-    case {{ type_spec.base_type | string | as_ros_python_type }}.{{ tag_spec.name }}:
+            {%- if loop.first %}
+if which == {{ type_spec.base_type | string | as_ros_python_type }}.{{ tag_spec.name }}:
+            {%- else %}
+elif which == {{ type_spec.base_type | string | as_ros_python_type }}.{{ tag_spec.name }}:
+            {%- endif %}
             {%- set source_member = source + "." + member_spec.name -%}
             {%- set destination_member = destination.rpartition(".")[0] + "." + member_spec.annotations.get("proto-name", member_spec.name) %}
-        {{ ros_to_proto_field_code(source_member, destination_member, member_spec) | indent(8) }}
+    {{ ros_to_proto_field_code(source_member, destination_member, member_spec) | indent(8) }}
         {%- endfor %}
-    case _:
-        pass
+else:
+    pass
     {%- else -%}
         {#- Handle the generic ROS message case (because it is appropriate or because we do not know any better). -#}
 convert_{{ spec.type | as_ros_base_type | as_python_identifier }}_message_to_{{ spec.annotations["proto-type"] | as_python_identifier }}_proto({{ source }}, {{ destination }})
@@ -214,19 +221,23 @@ else:
     raise ValueError("unknown protobuf message type in {{ spec.name }} member: %s" % {{ source }}.type_url)
     {%- elif type_spec and type_spec.annotations.get("tagged") -%}
         {#- Handle one-of field case i.e. determine and convert the Protobuf message member that is set. -#}
-match {{ source.rpartition(".")[0] }}.WhichOneof("{{ spec.name }}"):
-        {%- set tag_field_spec = type_spec.annotations["tag"] -%}
+which = {{ source.rpartition(".")[0] }}.WhichOneof("{{ spec.name }}")
+        {%- set tag_field_spec = type_spec.annotations["tag"] %}
         {%- for tag_spec, member_spec in type_spec.annotations["tagged"] %}
-    case "{{ member_spec.name }}":
-        {%- set source_member = source.rpartition(".")[0] + "." + member_spec.annotations.get("proto-name", member_spec.name) -%}
-        {%- set destination_member = destination + "." + member_spec.name %}
-        {{ proto_to_ros_field_code(source_member, destination_member, member_spec) | indent(8) }}
-        {{ destination }}.{{ tag_field_spec.name }} = {{ type_spec.base_type | string | as_ros_python_type }}.{{ tag_spec.name }}
-        {{ destination }}.{{ tag_field_spec.annotations["alias"] }} = {{ destination }}.{{ tag_field_spec.name }}
+            {%- if loop.first %}
+if which == "{{ member_spec.name }}":
+            {%- else %}
+elif which == "{{ member_spec.name }}":
+            {%- endif %}
+            {%- set source_member = source.rpartition(".")[0] + "." + member_spec.annotations.get("proto-name", member_spec.name) -%}
+            {%- set destination_member = destination + "." + member_spec.name %}
+    {{ proto_to_ros_field_code(source_member, destination_member, member_spec) | indent(8) }}
+    {{ destination }}.{{ tag_field_spec.name }} = {{ type_spec.base_type | string | as_ros_python_type }}.{{ tag_spec.name }}
+    {{ destination }}.{{ tag_field_spec.annotations["alias"] }} = {{ destination }}.{{ tag_field_spec.name }}
         {%- endfor %}
-    case _:
-        {{ destination }}.{{ tag_field_spec.name }} = 0
-        {{ destination }}.{{ tag_field_spec.annotations["alias"] }} = 0
+else:
+    {{ destination }}.{{ tag_field_spec.name }} = 0
+    {{ destination }}.{{ tag_field_spec.annotations["alias"] }} = 0
     {%- else -%}
         {#- Handle the generic Protobuf message case (because it is appropriate or because we do not know any better). -#}
 convert_{{ spec.annotations["proto-type"] | as_python_identifier }}_proto_to_{{ spec.type | as_ros_base_type | as_python_identifier }}_message({{ source }}, {{ destination }})

--- a/proto2ros/proto2ros/utilities.py
+++ b/proto2ros/proto2ros/utilities.py
@@ -47,7 +47,7 @@ def pairwise(iterable: Iterable[Any]) -> Iterable[Tuple[Any, Any]]:
     """Yields an iterable over consecutive pairs."""
     a, b = itertools.tee(iterable)
     next(b, None)
-    return zip(a, b)  # noqa: B905
+    return zip(a, b)
 
 
 def to_ros_base_type(type_: Union[str, BaseType]) -> str:


### PR DESCRIPTION
This slipped through during #44 and #59, and surfaced in #58. We became essentially incompatible with Python 3.8. 

This patch restores compatibility with Python 3.8.