### PR TITLE
Fix indentation in `proto2ros` generated conversion APIs

### DIFF
--- a/proto2ros/proto2ros/output/templates/conversions.py.jinja
+++ b/proto2ros/proto2ros/output/templates/conversions.py.jinja
@@ -116,7 +116,7 @@ elif which == {{ type_spec.base_type | string | as_ros_python_type }}.{{ tag_spe
             {%- endif %}
             {%- set source_member = source + "." + member_spec.name -%}
             {%- set destination_member = destination.rpartition(".")[0] + "." + member_spec.annotations.get("proto-name", member_spec.name) %}
-    {{ ros_to_proto_field_code(source_member, destination_member, member_spec) | indent(8) }}
+    {{ ros_to_proto_field_code(source_member, destination_member, member_spec) | indent(4) }}
         {%- endfor %}
 else:
     pass
@@ -231,7 +231,7 @@ elif which == "{{ member_spec.name }}":
             {%- endif %}
             {%- set source_member = source.rpartition(".")[0] + "." + member_spec.annotations.get("proto-name", member_spec.name) -%}
             {%- set destination_member = destination + "." + member_spec.name %}
-    {{ proto_to_ros_field_code(source_member, destination_member, member_spec) | indent(8) }}
+    {{ proto_to_ros_field_code(source_member, destination_member, member_spec) | indent(4) }}
     {{ destination }}.{{ tag_field_spec.name }} = {{ type_spec.base_type | string | as_ros_python_type }}.{{ tag_spec.name }}
     {{ destination }}.{{ tag_field_spec.annotations["alias"] }} = {{ destination }}.{{ tag_field_spec.name }}
         {%- endfor %}

--- a/proto2ros_tests/proto/test.proto
+++ b/proto2ros_tests/proto/test.proto
@@ -26,6 +26,26 @@ message Fragment {
     repeated Fragment nested = 2;
 }
 
+// Heterogeneous pair.
+message Pair {
+    // Sequence first values.
+    Value first = 1;
+    // Sequence second values.
+    Value second = 2;
+}
+
+// Heterogeneous value.
+message Value {
+    oneof data {
+        // Numeric value.
+        float number = 1;
+        // Text value.
+        string text = 2;
+        // Pair value.
+        Pair pair = 3;
+    }
+}
+
 // Discrete motion request.
 message MotionRequest  {
     // Valid directions for motion.

--- a/proto2ros_tests/test/generated/Pair.msg
+++ b/proto2ros_tests/test/generated/Pair.msg
@@ -1,0 +1,10 @@
+# Heterogeneous pair.
+
+uint8 FIRST_FIELD_SET=1
+uint8 SECOND_FIELD_SET=2
+
+# Sequence first values.
+proto2ros_tests/Value first
+# Sequence second values.
+proto2ros_tests/Value second
+uint8 has_field 255

--- a/proto2ros_tests/test/generated/Value.msg
+++ b/proto2ros_tests/test/generated/Value.msg
@@ -1,0 +1,3 @@
+# Heterogeneous value.
+
+proto2ros_tests/ValueOneOfData data

--- a/proto2ros_tests/test/generated/ValueOneOfData.msg
+++ b/proto2ros_tests/test/generated/ValueOneOfData.msg
@@ -1,0 +1,14 @@
+
+int8 DATA_NOT_SET=0
+int8 DATA_NUMBER_SET=1
+int8 DATA_TEXT_SET=2
+int8 DATA_PAIR_SET=3
+
+# Numeric value.
+float32 number
+# Text value.
+string text
+# Pair value.
+proto2ros/Any pair  # is proto2ros_tests/Pair (type-erased)
+int8 data_choice  # deprecated
+int8 which

--- a/proto2ros_tests/test/test_proto2ros.py
+++ b/proto2ros_tests/test/test_proto2ros.py
@@ -42,6 +42,24 @@ def test_recursive_messages() -> None:
     assert other_proto_subfragment.payload == proto_subfragment.payload
 
 
+def test_circularly_dependent_messages() -> None:
+    proto_pair = test_pb2.Pair()
+    proto_pair.first.text = "interval"
+    proto_pair.second.pair.first.number = -0.5
+    proto_pair.second.pair.second.number = 0.5
+    ros_pair = proto2ros_tests.msg.Pair()
+    convert(proto_pair, ros_pair)
+    assert ros_pair.first.data.which == ros_pair.first.data.DATA_TEXT_SET
+    assert ros_pair.first.data.text == proto_pair.first.text
+    assert ros_pair.second.data.which == ros_pair.second.data.DATA_PAIR_SET
+    assert ros_pair.second.data.pair.type_name == "proto2ros_tests/Pair"
+    other_proto_pair = test_pb2.Pair()
+    convert(ros_pair, other_proto_pair)
+    assert other_proto_pair.first.text == proto_pair.first.text
+    assert other_proto_pair.second.pair.first.number == proto_pair.second.pair.first.number
+    assert other_proto_pair.second.pair.second.number == proto_pair.second.pair.second.number
+
+
 def test_messages_with_enums() -> None:
     proto_motion_request = test_pb2.MotionRequest()
     proto_motion_request.direction = test_pb2.MotionRequest.Direction.FORWARD


### PR DESCRIPTION
Precisely what the title says. Fallout after #61. Surfaced in https://github.com/bdaiinstitute/bosdyn_msgs/pull/18. I didn't test it well enough :man_facepalming: Took me a while to reproduce in a regression test though.