### PR TITLE
Added flag to not wait for action server

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
@@ -12,7 +12,9 @@ from bdai_ros2_wrappers.type_hints import Action
 class ActionClientWrapper(rclpy.action.ActionClient):
     """A wrapper for ros2's ActionClient for extra functionality"""
 
-    def __init__(self, action_type: Type[Action], action_name: str, node: Optional[Node] = None) -> None:
+    def __init__(
+        self, action_type: Type[Action], action_name: str, node: Optional[Node] = None, wait_for_server: bool = True
+    ) -> None:
         """Constructor
 
         Args:
@@ -25,9 +27,10 @@ class ActionClientWrapper(rclpy.action.ActionClient):
             raise ValueError("no ROS 2 node available (did you use bdai_ros2_wrapper.process.main?)")
         self._node = node
         super().__init__(self._node, action_type, action_name)
-        self._node.get_logger().info(f"Waiting for action server for {action_name}")
-        self.wait_for_server()
-        self._node.get_logger().info("Found server")
+        if wait_for_server:
+            self._node.get_logger().info(f"Waiting for action server for {action_name}")
+            self.wait_for_server()
+            self._node.get_logger().info("Found server")
 
     def send_goal_and_wait(
         self, action_name: str, goal: Action.Goal, timeout_sec: Optional[float] = None

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
@@ -21,6 +21,7 @@ class ActionClientWrapper(rclpy.action.ActionClient):
             action_type (Type[Action]): The type of the action
             action_name (str): The name of the action (for logging purposes)
             node (Optional[Node]): optional node for action client, defaults to the current process node
+            wait_for_server (bool): Whether to wait for the server
         """
         node = node or scope.node()
         if node is None:

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
@@ -13,7 +13,11 @@ class ActionClientWrapper(rclpy.action.ActionClient):
     """A wrapper for ros2's ActionClient for extra functionality"""
 
     def __init__(
-        self, action_type: Type[Action], action_name: str, node: Optional[Node] = None, wait_for_server: bool = True
+        self,
+        action_type: Type[Action],
+        action_name: str,
+        node: Optional[Node] = None,
+        wait_for_server: bool = True,
     ) -> None:
         """Constructor
 


### PR DESCRIPTION
I know this will soon be replaced with Actionables, but until that happens I would like the ability to not wait for the server as its needed to add some unit tests in the main repo.