### PR TITLE
Always upcase `proto2ros` constant names

### DIFF
--- a/proto2ros/proto2ros/equivalences.py
+++ b/proto2ros/proto2ros/equivalences.py
@@ -115,7 +115,7 @@ def compute_equivalence_for_enum(
     """
     constants: List[Constant] = []
     for value_path, value_descriptor in locate_repeated("value", descriptor):
-        constant = Constant("int32", value_descriptor.name, value_descriptor.number)
+        constant = Constant("int32", value_descriptor.name.upper(), value_descriptor.number)
         value_location = resolve(source, value_path, location)
         leading_comments = extract_leading_comments(value_location)
         if leading_comments:

--- a/proto2ros_tests/proto/test.proto
+++ b/proto2ros_tests/proto/test.proto
@@ -50,10 +50,10 @@ message Value {
 message MotionRequest  {
     // Valid directions for motion.
     enum Direction {
-        LEFT = 0;
-        RIGHT = 1;
-        FORWARD = 2;
-        BACKWARD = 3;
+        Left = 0;
+        Right = 1;
+        Forward = 2;
+        Backward = 3;
     }
     // Direction of motion.
     Direction direction = 1;

--- a/proto2ros_tests/test/test_proto2ros.py
+++ b/proto2ros_tests/test/test_proto2ros.py
@@ -62,7 +62,7 @@ def test_circularly_dependent_messages() -> None:
 
 def test_messages_with_enums() -> None:
     proto_motion_request = test_pb2.MotionRequest()
-    proto_motion_request.direction = test_pb2.MotionRequest.Direction.FORWARD
+    proto_motion_request.direction = test_pb2.MotionRequest.Direction.Forward
     proto_motion_request.speed = 1.0
     ros_motion_request = proto2ros_tests.msg.MotionRequest()
     convert(proto_motion_request, ros_motion_request)


### PR DESCRIPTION
This patch fixes a bug uncovered downstream by the recent Spot SDK release. Enum constant names in Protobuf can be mixed case, but constant names in ROS messages can only be uppercase. 