### PR TITLE
Skip mapped messages during `proto2ros` generation 

### DIFF
--- a/proto2ros/proto2ros/equivalences.py
+++ b/proto2ros/proto2ros/equivalences.py
@@ -482,6 +482,8 @@ def extract_equivalences_from_message(
         yield compute_equivalence_for_enum(enum_descriptor, source_descriptor, enum_location, config)
     for nested_path, nested_descriptor in locate_repeated("nested_type", message_descriptor):
         nested_location = resolve(source_descriptor, nested_path, location)
+        if protofqn(source_descriptor, nested_location) in config.message_mapping:
+            continue  # skip mapped messages
         yield from extract_equivalences_from_message(nested_descriptor, source_descriptor, nested_location, config)
 
 
@@ -504,4 +506,6 @@ def extract_equivalences_from_source(
         yield compute_equivalence_for_enum(enum_type, source_descriptor, enum_location, config)
     for message_path, message_type in locate_repeated("message_type", source_descriptor):
         message_location = resolve(source_descriptor, message_path)
+        if protofqn(source_descriptor, message_location) in config.message_mapping:
+            continue  # skip mapped messages
         yield from extract_equivalences_from_message(message_type, source_descriptor, message_location, config)

--- a/proto2ros_tests/CMakeLists.txt
+++ b/proto2ros_tests/CMakeLists.txt
@@ -5,6 +5,7 @@ project(proto2ros_tests)
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 find_package(rosidl_default_generators REQUIRED)
 
@@ -26,7 +27,7 @@ add_dependencies(
 
 rosidl_generate_interfaces(
   ${PROJECT_NAME} ${ros_messages}
-  DEPENDENCIES geometry_msgs builtin_interfaces proto2ros
+  DEPENDENCIES geometry_msgs sensor_msgs builtin_interfaces proto2ros
   SKIP_INSTALL
 )
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_messages_gen)

--- a/proto2ros_tests/config/overlay.yaml
+++ b/proto2ros_tests/config/overlay.yaml
@@ -10,6 +10,7 @@ message_mapping:
   bosdyn.api.SE3Pose: geometry_msgs/Pose
   bosdyn.api.SE3Velocity: geometry_msgs/Twist
   bosdyn.api.Wrench: geometry_msgs/Wrench
+  proto2ros_tests.Temperature: sensor_msgs/Temperature
 python_imports:
   - bosdyn.api.geometry_pb2
   - geometry_msgs.msg

--- a/proto2ros_tests/package.xml
+++ b/proto2ros_tests/package.xml
@@ -18,6 +18,7 @@ Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
 
   <exec_depend>python3-jinja2</exec_depend>
   <exec_depend>python3-networkx</exec_depend>

--- a/proto2ros_tests/proto/test.proto
+++ b/proto2ros_tests/proto/test.proto
@@ -11,11 +11,30 @@ import "google/protobuf/type.proto";
 
 import "bosdyn/api/geometry.proto";
 
+// Body relative directions for motion.
 enum Direction {
     LEFT = 0;
     RIGHT = 1;
     FORWARD = 2;
     BACKWARD = 3;
+}
+
+// Temperature measurement.
+message Temperature {
+    // Measurement temperature scale.
+    enum Scale {
+        CELSIUS = 0;
+        KELVIN = 1;
+        FAHRENHEIT = 2;
+    }
+    float value = 1;
+    Scale scale = 2;
+}
+
+// A control request for an HVAC system.
+message HVACControlRequest {
+    double air_flow_rate = 1;
+    Temperature temperature_setpoint = 2;
 }
 
 // Binary recursive fragment.

--- a/proto2ros_tests/proto2ros_tests/manual_conversions.py
+++ b/proto2ros_tests/proto2ros_tests/manual_conversions.py
@@ -2,6 +2,8 @@ import math
 
 import bosdyn.api.geometry_pb2
 import geometry_msgs.msg
+import sensor_msgs.msg
+import test_pb2
 
 from proto2ros.conversions import convert
 
@@ -155,9 +157,31 @@ def convert_geometry_msgs_wrench_message_to_bosdyn_api_wrench_proto(
 
 
 @convert.register(bosdyn.api.geometry_pb2.Wrench, geometry_msgs.msg.Wrench)
-def convert_bosdyn_api_wrench_proto_to_geometry_msgs_wrench_messagey(
+def convert_bosdyn_api_wrench_proto_to_geometry_msgs_wrench_message(
     proto_msg: bosdyn.api.geometry_pb2.Wrench,
     ros_msg: geometry_msgs.msg.Wrench,
 ) -> None:
     convert_bosdyn_api_vec3_proto_to_geometry_msgs_vector3_message(proto_msg.force, ros_msg.force)
     convert_bosdyn_api_vec3_proto_to_geometry_msgs_vector3_message(proto_msg.torque, ros_msg.torque)
+
+
+@convert.register(sensor_msgs.msg.Temperature, test_pb2.Temperature)
+def convert_sensor_msgs_temperature_message_to_proto2ros_tests_temperature_proto(
+    ros_msg: sensor_msgs.msg.Temperature,
+    proto_msg: test_pb2.Temperature,
+) -> None:
+    proto_msg.scale = test_pb2.Temperature.Scale.CELSIUS
+    proto_msg.value = ros_msg.temperature
+
+
+@convert.register(test_pb2.Temperature, sensor_msgs.msg.Temperature)
+def convert_proto2ros_tests_temperature_proto_to_sensor_msgs_temperature_message(
+    proto_msg: test_pb2.Temperature,
+    ros_msg: sensor_msgs.msg.Temperature,
+) -> None:
+    if proto_msg.scale == test_pb2.Temperature.Scale.KELVIN:
+        ros_msg.temperature = proto_msg.value + 273
+    elif proto_msg.scale == test_pb2.Temperature.Scale.FAHRENHEIT:
+        ros_msg.temperature = (proto_msg.value - 32) * 5 / 9
+    else:  # proto_msg.scale == test_pb2.Temperature.Scale.CELSIUS
+        ros_msg.temperature = proto_msg.value

--- a/proto2ros_tests/test/generated/Direction.msg
+++ b/proto2ros_tests/test/generated/Direction.msg
@@ -1,3 +1,4 @@
+# Body relative directions for motion.
 
 int32 LEFT=0
 int32 RIGHT=1

--- a/proto2ros_tests/test/test_proto2ros.py
+++ b/proto2ros_tests/test/test_proto2ros.py
@@ -24,6 +24,23 @@ def test_message_generation() -> None:
     assert not errors, errors
 
 
+def test_message_mapping() -> None:
+    assert not hasattr(proto2ros_tests.msg, "Temperature")
+    assert not hasattr(proto2ros_tests.msg, "TemperatureScale")
+    proto_request = test_pb2.HVACControlRequest()
+    proto_request.air_flow_rate = 1000.0
+    proto_request.temperature_setpoint.value = 77.0
+    proto_request.temperature_setpoint.scale = test_pb2.Temperature.Scale.FAHRENHEIT
+    ros_request = proto2ros_tests.msg.HVACControlRequest()
+    convert(proto_request, ros_request)
+    other_proto_request = test_pb2.HVACControlRequest()
+    convert(ros_request, other_proto_request)
+    assert proto_request.air_flow_rate == other_proto_request.air_flow_rate
+    # sensor_msgs/Temperature messages are in the Celsius temperature scale
+    assert other_proto_request.temperature_setpoint.value == 25.0
+    assert other_proto_request.temperature_setpoint.scale == test_pb2.Temperature.Scale.CELSIUS
+
+
 def test_recursive_messages() -> None:
     proto_fragment = test_pb2.Fragment()
     proto_fragment.payload = b"important data"


### PR DESCRIPTION
This patch fixes a bug in `proto2ros` message mapping support, in which an equivalent ROS message would still be generated for a mapped Protobuf message only because it happens to be in the sources that are being parsed.

The actual fix is in `proto2ros.equivalences`. Everything else is a regression test.