### PR TITLE
Fix `bdai_ros2_wrappers.scope.current()` implementation

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/scope.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/scope.py
@@ -506,7 +506,7 @@ def top(
 
 def current() -> typing.Optional[ROSAwareScope]:
     """Gets the current ROS 2 aware scope, if any."""
-    return getattr(ROSAwareScope.local, "top", ROSAwareScope.global_)
+    return ROSAwareScope.local.top or ROSAwareScope.global_
 
 
 def node() -> typing.Optional[rclpy.node.Node]:


### PR DESCRIPTION
Ran into this while preparing tutorial code. It turns out that `threading.local` objects yield `None` for previously unset attributes, so `getattr` is not the proper strategy to implement this fallback logic.