### PR TITLE
Set CMP0148 for `proto2ros` packages

### DIFF
--- a/proto2ros/CMakeLists.txt
+++ b/proto2ros/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 cmake_minimum_required(VERSION 3.8)
+cmake_policy(SET CMP0148 OLD)  # to accommodate rosidl pipeline
 project(proto2ros)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/proto2ros/CMakeLists.txt
+++ b/proto2ros/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 cmake_minimum_required(VERSION 3.8)
-cmake_policy(SET CMP0148 OLD)  # to accommodate rosidl pipeline
+if(POLICY CMP0148)
+  cmake_policy(SET CMP0148 OLD)  # to accommodate rosidl pipeline
+endif()
 project(proto2ros)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/proto2ros/proto2ros-extras.cmake
+++ b/proto2ros/proto2ros-extras.cmake
@@ -2,13 +2,13 @@
 include("${proto2ros_DIR}/rosidl_helpers.cmake")
 
 find_package(Python3 REQUIRED)
-find_package(PythonInterp REQUIRED)  # to prevent failure deep down rosidl
 find_package(Protobuf REQUIRED)
 if(BUILD_TESTING)
   find_package(ament_cmake_mypy QUIET)
 endif()
 include("${proto2ros_DIR}/proto2ros_generate.cmake")
 
+cmake_policy(SET CMP0148 OLD)  # to accomodate rosidl pipeline
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 include("${proto2ros_DIR}/proto2ros_vendor_package.cmake")

--- a/proto2ros/proto2ros-extras.cmake
+++ b/proto2ros/proto2ros-extras.cmake
@@ -8,7 +8,9 @@ if(BUILD_TESTING)
 endif()
 include("${proto2ros_DIR}/proto2ros_generate.cmake")
 
-cmake_policy(SET CMP0148 OLD)  # to accomodate rosidl pipeline
+if(POLICY CMP0148)
+  cmake_policy(SET CMP0148 OLD)  # to accommodate rosidl pipeline
+endif()
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 include("${proto2ros_DIR}/proto2ros_vendor_package.cmake")

--- a/proto2ros_tests/CMakeLists.txt
+++ b/proto2ros_tests/CMakeLists.txt
@@ -1,15 +1,15 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 cmake_minimum_required(VERSION 3.12)
+cmake_policy(SET CMP0148 OLD)  # to accommodate rosidl pipeline
 project(proto2ros_tests)
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(proto2ros REQUIRED)
 
 find_package(rosidl_default_generators REQUIRED)
-
-find_package(proto2ros REQUIRED)
 
 add_subdirectory(proto)
 

--- a/proto2ros_tests/CMakeLists.txt
+++ b/proto2ros_tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 cmake_minimum_required(VERSION 3.12)
-cmake_policy(SET CMP0148 OLD)  # to accommodate rosidl pipeline
+if(POLICY CMP0148)
+  cmake_policy(SET CMP0148 OLD)  # to accommodate rosidl pipeline
+endif()
 project(proto2ros_tests)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Precisely what the title says. `rosidl` packages are relying on old CMake modules and that's causing warnings (and sometimes errors, for newer CMake versions?) downstream. 