### PR TITLE
Find PythonInterp in proto2ros-extras.cmake

### DIFF
--- a/proto2ros/proto2ros-extras.cmake
+++ b/proto2ros/proto2ros-extras.cmake
@@ -1,16 +1,17 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 include("${proto2ros_DIR}/rosidl_helpers.cmake")
+if(POLICY CMP0148)
+  cmake_policy(SET CMP0148 OLD)  # to accommodate rosidl pipeline
+endif()
 
 find_package(Python3 REQUIRED)
+find_package(PythonInterp REQUIRED)
 find_package(Protobuf REQUIRED)
 if(BUILD_TESTING)
   find_package(ament_cmake_mypy QUIET)
 endif()
 include("${proto2ros_DIR}/proto2ros_generate.cmake")
 
-if(POLICY CMP0148)
-  cmake_policy(SET CMP0148 OLD)  # to accommodate rosidl pipeline
-endif()
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 include("${proto2ros_DIR}/proto2ros_vendor_package.cmake")


### PR DESCRIPTION
Follow-up to #73. It seems we have an interesting cocktail of Python / CMake versions in our development environments. We need #73 for the institute's codebase to build, and we also need this for `bosydn_msgs` to build.