### PR TITLE
Relocate `ROSAwareProcess` sanity checks to call

### DIFF
--- a/bdai_ros2_wrappers/test/test_process.py
+++ b/bdai_ros2_wrappers/test/test_process.py
@@ -84,7 +84,7 @@ def test_cli_configuration() -> None:  # type: ignore
         parser.set_defaults(process_args=lambda args: dict(forward_logging=not args.quiet))
         return parser
 
-    @process.main(cli(), namespace="{robot}")
+    @process.main(cli(), namespace="/{robot}")
     def main(args: argparse.Namespace) -> int:
         assert main.node is not None
         assert main.node.get_fully_qualified_name() == "/spot/test_command"


### PR DESCRIPTION
Precisely what the title says. Validating node name and namespace on `ROSAwareProcess` construction misses CLI overrides and may trigger unintended warnings when the module hosting a `@ros_process.main` decorated function is imported. This patch moves these checks from `__init__` to `__call__`.