### PR TITLE
Cancel pending work for destroyed nodes

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/executors.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/executors.py
@@ -510,17 +510,30 @@ class AutoScalingMultiThreadedExecutor(rclpy.executors.Executor):
     class Task:
         """A bundle of an executable task and its associated entity."""
 
-        def __init__(self, task: rclpy.task.Task, entity: typing.Optional[rclpy.executors.WaitableEntityType]) -> None:
+        def __init__(
+            self,
+            task: rclpy.task.Task,
+            entity: typing.Optional[rclpy.executors.WaitableEntityType],
+            node: typing.Optional[rclpy.node.Node],
+        ) -> None:
             self.task = task
             self.entity = entity
+            self.valid = lambda: True
+            if node is not None and hasattr(node, "destruction_requested"):
+                self.valid = lambda: not node.destruction_requested  # type: ignore
+            else:
+                self.valid = lambda: True
             self.callback_group = entity.callback_group if entity is not None else None
 
         def __call__(self) -> None:
-            """Run or resume a task
+            """Run or resume a task.
 
             See rclpy.task.Task documentation for further reference.
             """
-            self.task.__call__()
+            if not self.valid():
+                self.cancel()
+                return
+            self.task()
 
         def __getattr__(self, name: str) -> typing.Any:
             return getattr(self.task, name)
@@ -591,7 +604,7 @@ class AutoScalingMultiThreadedExecutor(rclpy.executors.Executor):
         with self._spin_lock:
             try:
                 task, entity, node = self.wait_for_ready_callbacks(*args, **kwargs)
-                task = AutoScalingMultiThreadedExecutor.Task(task, entity)
+                task = AutoScalingMultiThreadedExecutor.Task(task, entity, node)
                 with self._shutdown_lock:
                     if self._is_shutdown:
                         # Ignore task, let shutdown clean it up.
@@ -665,8 +678,9 @@ class AutoScalingMultiThreadedExecutor(rclpy.executors.Executor):
             with self._spin_lock:
                 # rclpy.executors.Executor base implementation leaves tasks
                 # unawaited upon shutdown. Do the housekeepng.
-                for task, entity, _ in self._tasks:
-                    task = AutoScalingMultiThreadedExecutor.Task(task, entity)
+                for task, entity, node in self._tasks:
+                    Task = AutoScalingMultiThreadedExecutor.Task
+                    task = Task(task, entity, node)
                     task.cancel()
         return done
 

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/executors.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/executors.py
@@ -518,7 +518,6 @@ class AutoScalingMultiThreadedExecutor(rclpy.executors.Executor):
         ) -> None:
             self.task = task
             self.entity = entity
-            self.valid = lambda: True
             if node is not None and hasattr(node, "destruction_requested"):
                 self.valid = lambda: not node.destruction_requested  # type: ignore
             else:
@@ -679,8 +678,7 @@ class AutoScalingMultiThreadedExecutor(rclpy.executors.Executor):
                 # rclpy.executors.Executor base implementation leaves tasks
                 # unawaited upon shutdown. Do the housekeepng.
                 for task, entity, node in self._tasks:
-                    Task = AutoScalingMultiThreadedExecutor.Task
-                    task = Task(task, entity, node)
+                    task = AutoScalingMultiThreadedExecutor.Task(task, entity, node)
                     task.cancel()
         return done
 

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/node.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/node.py
@@ -28,6 +28,7 @@ class Node(BaseNode):
         if default_callback_group is None:
             default_callback_group = NonReentrantCallbackGroup()
         self._default_callback_group_override = default_callback_group
+        self._destruction_requested = False
         super().__init__(*args, **kwargs)
 
     @property
@@ -35,3 +36,13 @@ class Node(BaseNode):
         """Get the default callback group."""
         # NOTE(hidmic): this overrides the hardcoded default group in rclpy.node.Node implementation
         return self._default_callback_group_override
+
+    @property
+    def destruction_requested(self) -> bool:
+        """Checks whether destruction was requested or not."""
+        return self._destruction_requested
+
+    def destroy_node(self) -> None:
+        """Overrides node destruction API."""
+        self._destruction_requested = True
+        super().destroy_node()

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/scope.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/scope.py
@@ -309,6 +309,10 @@ class ROSAwareScope(typing.ContextManager["ROSAwareScope"]):
     def load(self, factory: NodeFactoryCallable, *args: typing.Any, **kwargs: typing.Any) -> rclpy.node.Node:
         """Instantiates and loads a ROS 2 node.
 
+        If a __post_init__ method is defined by the instantiated ROS 2 node, it will be invoked
+        after the node is added to the scope executor. This allows for blocking calls during
+        initialization, provided the scope executor can serve them in the background.
+
         Args:
             factory: callable to instantiate a ROS 2 node.
             It is expected to accept `rclpy.node.Node` arguments.
@@ -332,6 +336,10 @@ class ROSAwareScope(typing.ContextManager["ROSAwareScope"]):
         **kwargs: typing.Any,
     ) -> typing.List[rclpy.node.Node]:
         """Instantiates and loads a collection (or graph) of ROS 2 nodes.
+
+        For each ROS 2 node instantiated, if a __post_init__ method is defined it will be invoked
+        after the corresponding node has been added to the scope executor. This allows for blocking
+        calls during initialization, provided the scope executor can serve them in the background.
 
         Args:
             factory: callable to instantiate a collection of ROS 2 nodes.

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/scope.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/scope.py
@@ -309,10 +309,6 @@ class ROSAwareScope(typing.ContextManager["ROSAwareScope"]):
     def load(self, factory: NodeFactoryCallable, *args: typing.Any, **kwargs: typing.Any) -> rclpy.node.Node:
         """Instantiates and loads a ROS 2 node.
 
-        If a __post_init__ method is defined by the instantiated ROS 2 node, it will be invoked
-        after the node is added to the scope executor. This allows for blocking calls during
-        initialization, provided the scope executor can serve them in the background.
-
         Args:
             factory: callable to instantiate a ROS 2 node.
             It is expected to accept `rclpy.node.Node` arguments.
@@ -336,10 +332,6 @@ class ROSAwareScope(typing.ContextManager["ROSAwareScope"]):
         **kwargs: typing.Any,
     ) -> typing.List[rclpy.node.Node]:
         """Instantiates and loads a collection (or graph) of ROS 2 nodes.
-
-        For each ROS 2 node instantiated, if a __post_init__ method is defined it will be invoked
-        after the corresponding node has been added to the scope executor. This allows for blocking
-        calls during initialization, provided the scope executor can serve them in the background.
 
         Args:
             factory: callable to instantiate a collection of ROS 2 nodes.

--- a/bdai_ros2_wrappers/test/test_node.py
+++ b/bdai_ros2_wrappers/test/test_node.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2024 Boston Dynamics AI Institute Inc.  All rights reserved.
+
+import threading
+from typing import Generator
+
+import pytest
+import rclpy
+from rclpy.context import Context
+from std_srvs.srv import Trigger
+
+from bdai_ros2_wrappers.executors import AutoScalingMultiThreadedExecutor
+from bdai_ros2_wrappers.node import Node
+
+
+@pytest.fixture
+def ros_context() -> Generator[Context, None, None]:
+    """A fixture yielding a managed rclpy.context.Context instance."""
+    context = Context()
+    rclpy.init(context=context)
+    try:
+        yield context
+    finally:
+        context.try_shutdown()
+
+
+def test_node_destruction_during_execution(ros_context: Context) -> None:
+    """Asserts that node destructionthe autoscaling multithreaded executor scales to attend a
+    synchronous service call from a "one-shot" timer callback, serviced by
+    the same executor.
+    """
+
+    def dummy_server_callback(_: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        response.success = True
+        return response
+
+    node = Node("pytest_node", context=ros_context)
+    node.create_service(Trigger, "/dummy/trigger", dummy_server_callback)
+    client = node.create_client(Trigger, "/dummy/trigger")
+
+    executor = AutoScalingMultiThreadedExecutor(max_threads=1, context=ros_context)
+    executor.add_node(node)
+
+    barrier = threading.Barrier(2)
+    try:
+        # First smoke test the executor with a service invocation
+        future = client.call_async(Trigger.Request())
+        executor.spin_until_future_complete(future, timeout_sec=5.0)
+        assert future.done() and future.result().success
+        # Then block its sole worker thread
+        executor.create_task(lambda: barrier.wait())
+        executor.spin_once()
+        # Then queue node destruction
+        executor.create_task(lambda: node.destroy_node())
+        executor.spin_once()
+        assert not node.destruction_requested  # still queued
+        # Then queue another service invocation
+        future = client.call_async(Trigger.Request())
+        executor.spin_once()
+        # Unblock worker thread in executor
+        barrier.wait()
+        # Check that executor wraps up early due to node destruction
+        executor.spin_until_future_complete(future, timeout_sec=5.0)
+        assert node.destruction_requested
+        assert executor.thread_pool.wait(timeout=5.0)
+        assert not future.done()  # future response will never be resolved
+    finally:
+        barrier.reset()
+        executor.remove_node(node)
+        executor.shutdown()


### PR DESCRIPTION
Precisely what the title says. This patch enables `AutoscalingMultiThreadedExecutor` instances to cancel pending work originated on nodes that have since been destroyed. This will only apply to `bdai_ros2_wrappers.node.Node` instances (`rclpy.node.Node` do not provide the means for the executor to tell if destruction has been requested).