### PR TITLE
Add support for Node post-initialization

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/scope.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/scope.py
@@ -366,10 +366,14 @@ class ROSAwareScope(typing.ContextManager["ROSAwareScope"]):
                 graph = list(node_or_graph)
                 for node in graph:
                     self._executor.add_node(node)
+                    if hasattr(node, "__post_init__"):
+                        node.__post_init__()
                 self._graph.extend(graph)
                 return graph
             node = node_or_graph
             self._executor.add_node(node)
+            if hasattr(node, "__post_init__"):
+                node.__post_init__()
             self._graph.append(node)
             return node
 

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/scope.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/scope.py
@@ -309,6 +309,10 @@ class ROSAwareScope(typing.ContextManager["ROSAwareScope"]):
     def load(self, factory: NodeFactoryCallable, *args: typing.Any, **kwargs: typing.Any) -> rclpy.node.Node:
         """Instantiates and loads a ROS 2 node.
 
+        If a __post_init__ method is defined by the instantiated ROS 2 node, it will be invoked
+        after the node is added to the scope executor. This allows for blocking calls during
+        initialization, provided the scope executor can serve them in the background.
+
         Args:
             factory: callable to instantiate a ROS 2 node.
             It is expected to accept `rclpy.node.Node` arguments.
@@ -332,6 +336,10 @@ class ROSAwareScope(typing.ContextManager["ROSAwareScope"]):
         **kwargs: typing.Any,
     ) -> typing.List[rclpy.node.Node]:
         """Instantiates and loads a collection (or graph) of ROS 2 nodes.
+
+        For each ROS 2 node instantiated, if a __post_init__ method is defined it will be invoked
+        after the corresponding node has been added to the scope executor. This allows for blocking
+        calls during initialization, provided the scope executor can serve them in the background.
 
         Args:
             factory: callable to instantiate a collection of ROS 2 nodes.

--- a/bdai_ros2_wrappers/test/test_node.py
+++ b/bdai_ros2_wrappers/test/test_node.py
@@ -5,14 +5,13 @@ from typing import Any, Generator
 
 import pytest
 import rclpy
-from rclpy.context import Context
 from rcl_interfaces.srv import GetParameters
+from rclpy.context import Context
 from std_srvs.srv import Trigger
 
 from bdai_ros2_wrappers.executors import AutoScalingMultiThreadedExecutor
-from bdai_ros2_wrappers.scope import ROSAwareScope
-
 from bdai_ros2_wrappers.node import Node
+from bdai_ros2_wrappers.scope import ROSAwareScope
 
 
 @pytest.fixture


### PR DESCRIPTION
Precisely what the title says. This patch allows for `Node` initialization to be split between `__init__` and `__post_init__` methods, where the latter are invoked **after** the node has been loaded to a scope, enabling blocking calls.