### PR TITLE
Speed up `rclpy` loggers 

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/utilities.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/utilities.py
@@ -4,6 +4,10 @@ import functools
 import threading
 import typing
 
+import rclpy.clock
+import rclpy.duration
+import rclpy.time
+
 
 def namespace_with(*args: typing.Optional[str]) -> str:
     """Puts together a ROS 2 like namespace from its constitutive parts."""
@@ -89,3 +93,122 @@ def synchronized(
     if func is None:
         return _decorator
     return _decorator(func)
+
+
+def functional_decorator(base_decorator: typing.Callable) -> typing.Callable:
+    """Wraps a decorating callable to be usable as a Python decorator for functions.
+
+    As an example, consider the following decorator example:
+
+    @functional_decorator
+    def my_decorator(func, some_flag=None):
+        ...
+
+    This decorator can then be used like this:
+
+    @my_decorator
+    def my_function(*args):
+        ...
+
+    and also like this:
+
+    @my_decorator(some_flag=True)
+    def my_function(*args):
+        ...
+    """
+
+    @functools.wraps(base_decorator)
+    def _wrapper(func: typing.Optional[typing.Callable] = None, **kwargs: typing.Any) -> typing.Callable:
+        def _bound_decorator(func: typing.Callable) -> typing.Callable:
+            return base_decorator(func, **kwargs)
+
+        if func is None:
+            return _bound_decorator
+        return _bound_decorator(func)
+
+    return _wrapper
+
+
+@functional_decorator
+def throttle(
+    func: typing.Callable,
+    min_period: rclpy.duration.Duration,
+    time_source: typing.Optional[rclpy.clock.Clock] = None,
+    fill_value: typing.Any = None,
+) -> typing.Callable:
+    """Decorates a callable to throttle invocations.
+
+    Args:
+        func: callable to be decorated.
+        min_period: minimum time between consecutive invocations.
+        time_source: optional time source to measure time against.
+        If none is provided, the system clock will be used.
+        fill_value: optional value to return for throttled invocations.
+
+    Returns:
+        decorated callable.
+    """
+    safe_time_source = rclpy.clock.Clock() if time_source is None else time_source
+    time_of_last_call: typing.Optional[rclpy.time.Time] = None
+
+    @functools.wraps(func)
+    def _wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        nonlocal time_of_last_call
+        return_value = fill_value
+        current_time = safe_time_source.now()
+        if time_of_last_call is None or current_time - time_of_last_call >= min_period:
+            return_value = func(*args, **kwargs)
+            time_of_last_call = current_time
+        return return_value
+
+    return _wrapper
+
+
+@functional_decorator
+def skip(func: typing.Callable, num_times: int, fill_value: typing.Any = None) -> typing.Callable:
+    """Decorates a callable to skip the first few invocations a prescribed number of times.
+
+    Args:
+        func: callable to be decorated.
+        num_times: number of times to skip the invocation.
+        fill_value: optional value to return for skipped invocations.
+
+    Returns:
+        decorated callable.
+    """
+    num_skipped_calls = 0
+
+    @functools.wraps(func)
+    def _wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        nonlocal num_skipped_calls
+        if num_skipped_calls < num_times:
+            num_skipped_calls += 1
+            return fill_value
+        return func(*args, **kwargs)
+
+    return _wrapper
+
+
+@functional_decorator
+def cap(func: typing.Callable, num_times: int, fill_value: typing.Any = None) -> typing.Callable:
+    """Decorates a callable to cap invocations to a prescribed number of times.
+
+    Args:
+        func: callable to be decorated.
+        num_times: maximum number of times the callable may be invoked.
+        fill_value: optional value to return once invocations reach their cap.
+
+    Returns:
+        decorated callable.
+    """
+    num_calls = 0
+
+    @functools.wraps(func)
+    def _wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        nonlocal num_calls
+        if num_calls < num_times:
+            num_calls += 1
+            return func(*args, **kwargs)
+        return fill_value
+
+    return _wrapper

--- a/bdai_ros2_wrappers/test/test_logging.py
+++ b/bdai_ros2_wrappers/test/test_logging.py
@@ -1,13 +1,78 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
 import logging
-from typing import Optional
+import threading
+from typing import List, Optional
 
 from rcl_interfaces.msg import Log
+from rclpy.clock import ROSClock
 from rclpy.task import Future
+from rclpy.time import Time
 
 from bdai_ros2_wrappers.futures import wait_for_future
-from bdai_ros2_wrappers.logging import logs_to_ros
+from bdai_ros2_wrappers.logging import LoggingSeverity, as_memoizing_logger, logs_to_ros
 from bdai_ros2_wrappers.scope import ROSAwareScope
+
+
+def test_memoizing_logger(verbose_ros: ROSAwareScope) -> None:
+    messages: List[str] = []
+    cv = threading.Condition()
+
+    def callback(message: Log) -> None:
+        nonlocal messages, cv
+        with cv:
+            messages.append(message.msg)
+            cv.notify()
+
+    assert verbose_ros.node is not None
+    verbose_ros.node.create_subscription(Log, "/rosout", callback, 10)
+
+    logger = as_memoizing_logger(verbose_ros.node.get_logger())
+    logger.set_level(LoggingSeverity.INFO)
+
+    assert not logger.debug("Debug message should not be logged")
+
+    for i in range(2):
+        is_first_iteration = i == 0
+        did_log_once = logger.error(
+            f"Error message should have been logged only if {i} == 0",
+            once=True,
+        )
+        assert did_log_once == is_first_iteration
+        did_skip_first_log = logger.error(
+            f"Error message should have been logged only if {i} != 0",
+            skip_first=True,
+        )
+        assert did_skip_first_log != is_first_iteration
+
+    assert logger.warning("Warning message always logged", once=True)
+    assert logger.warning("Warning message always logged", once=True)
+
+    fake_clock = ROSClock()
+    fake_clock._set_ros_time_is_active(True)
+
+    num_throttled_logs = 2
+    num_attempts_per_sec = 5
+    for i in range(num_attempts_per_sec * num_throttled_logs):
+        fake_clock.set_ros_time_override(Time(seconds=float(i) / num_attempts_per_sec))
+        assert logger.info(
+            "Info message should be throttled",
+            throttle_duration_sec=1.0,
+            throttle_time_source_type=fake_clock,
+        ) == (i % num_attempts_per_sec == 0)
+
+    expected_messages = [
+        "Error message should have been logged only if 0 == 0",
+        "Error message should have been logged only if 1 != 0",
+        "Warning message always logged",
+        "Warning message always logged",
+    ] + ["Info message should be throttled"] * num_throttled_logs
+
+    def all_messages_arrived() -> bool:
+        return len(messages) == len(expected_messages)
+
+    with cv:
+        assert cv.wait_for(all_messages_arrived, timeout=5.0)
+    assert messages == expected_messages
 
 
 def test_log_forwarding(verbose_ros: ROSAwareScope) -> None:


### PR DESCRIPTION
This patch introduces an alternative implementation of the `rclpy.logging.RcutilsLogger` that will cache log call configurations. This has been observed to reduce the average logging time significantly. 

As to why this is the case, other than the obvious advantage of executing code on first call rather than on every call, I suspect stack frame inspection in Python may be taking some amount of time (as it fetches code from source files by default when populating frame info and traceback objects, see [here](https://github.com/python/cpython/blob/fad48ea1816be3125ea51edcdfe2f999d6ade796/Lib/inspect.py#L1707)).