### PR TITLE
Fix `wait_for_future` for cancelled futures

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/futures.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/futures.py
@@ -23,5 +23,7 @@ def wait_for_future(future: Future, timeout_sec: Optional[float] = None, *, cont
     event = Event()
     context.on_shutdown(event.set)
     future.add_done_callback(lambda _: event.set())
+    if future.cancelled():
+        event.set()
     event.wait(timeout=timeout_sec)
     return future.done()

--- a/bdai_ros2_wrappers/test/test_futures.py
+++ b/bdai_ros2_wrappers/test/test_futures.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 Boston Dynamics AI Institute Inc.  All rights reserved.
+
+from rclpy.task import Future
+
+from bdai_ros2_wrappers.futures import wait_for_future
+from bdai_ros2_wrappers.scope import ROSAwareScope
+
+
+def test_wait_for_cancelled_future(ros: ROSAwareScope) -> None:
+    """Asserts that waiting for a cancelled future does not hang indefinitely."""
+    future = Future()
+    future.cancel()
+
+    assert not wait_for_future(future, context=ros.context)
+    assert future.cancelled()


### PR DESCRIPTION
This patch copes with how `rclpy.task.Future` deals with cancellation (done callbacks trigger on cancel but the future never becomes done, a done callback added to a cancelled future will never be invoked because the future is not done 😵‍💫). 