### PR TITLE
[EK-35] Use `MemoizingRcutilsLogger` in `bdai_ros2_wrappers.node.Node`

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/node.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/node.py
@@ -5,12 +5,14 @@ from rclpy.callback_groups import CallbackGroup
 from rclpy.node import Node as BaseNode
 
 from bdai_ros2_wrappers.callback_groups import NonReentrantCallbackGroup
+from bdai_ros2_wrappers.logging import MemoizingRcutilsLogger, as_memoizing_logger
 
 
 class Node(BaseNode):
     """An rclpy.node.Node subclass that:
 
-    * changes the default callback group to be non-reentrant.
+    * changes the default callback group to be non-reentrant
+    * wraps its logger with a memoizing one for improved efficiency
     """
 
     def __init__(self, *args: Any, default_callback_group: Optional[CallbackGroup] = None, **kwargs: Any) -> None:
@@ -30,6 +32,7 @@ class Node(BaseNode):
         self._default_callback_group_override = default_callback_group
         self._destruction_requested = False
         super().__init__(*args, **kwargs)
+        self._logger: MemoizingRcutilsLogger = as_memoizing_logger(self._logger)
 
     @property
     def default_callback_group(self) -> CallbackGroup:


### PR DESCRIPTION
Follow-up to #84. In hindsight, automatically providing a memoizing logger to all `bdai_ros2_wrappers.node.Node` users makes for a much less painful migration and it spares us two migration cycles when and if we submit this upstream.