### PR TITLE
Avoid instance checks for future like objects

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/futures.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/futures.py
@@ -8,7 +8,6 @@ from rclpy.utilities import get_default_context
 T = TypeVar("T", covariant=True)
 
 
-@runtime_checkable
 class FutureLike(Awaitable[T], Protocol[T]):
     """A future-like awaitable object.
 
@@ -40,6 +39,7 @@ class FutureLike(Awaitable[T], Protocol[T]):
         ...
 
 
+@runtime_checkable
 class FutureConvertible(Awaitable[T], Protocol[T]):
     """An awaitable that is convertible to a future-like object."""
 
@@ -53,9 +53,9 @@ AnyFuture = Union[FutureLike, FutureConvertible]
 
 def as_proper_future(instance: AnyFuture) -> FutureLike:
     """Return `instance` as a proper future-like object."""
-    if isinstance(instance, FutureLike):
-        return instance
-    return instance.as_future()
+    if isinstance(instance, FutureConvertible):
+        return instance.as_future()
+    return instance
 
 
 def wait_for_future(


### PR DESCRIPTION
Follow-up to #92. Runtime `typing.Protocol` checks in Python 3.10 do [more than they should](https://github.com/python/cpython/blob/333c7dccd87c637d0b15cf81f9bbec28e39664fd/Lib/typing.py#L1505-L1511), causing sporadic CI breakage (see https://github.com/bdaiinstitute/ros_utilities/actions/runs/9098900296/job/25010366084#step:4:186).

This patch works around it.