### PR TITLE
Add callbacks to message feeds

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/feeds.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/feeds.py
@@ -8,7 +8,7 @@ from rclpy.node import Node
 from rclpy.task import Future
 
 import bdai_ros2_wrappers.scope as scope
-from bdai_ros2_wrappers.filters import SimpleAdapter, TransformFilter
+from bdai_ros2_wrappers.filters import SimpleAdapter, TransformFilter, Tunnel
 from bdai_ros2_wrappers.utilities import Tape
 
 
@@ -68,6 +68,16 @@ class MessageFeed:
             a future.
         """
         return self._tape.future_matching_write(matching_predicate)
+
+    def recall(self, callback: Callable) -> Tunnel:
+        """Adds a callback for message recalling.
+
+        Returns:
+            the underlying connection, which can be closed to stop future callbacks.
+        """
+        tunnel = Tunnel(self.link)
+        tunnel.registerCallback(callback)
+        return tunnel
 
     def stream(
         self,

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/filters.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/filters.py
@@ -145,6 +145,7 @@ class Tunnel(SimpleFilter):
         Args:
             upstream: the upstream message filter.
         """
+        super().__init__()
         self.upstream = upstream
         self.connection = upstream.registerCallback(self.signalMessage)
 

--- a/bdai_ros2_wrappers/test/test_feeds.py
+++ b/bdai_ros2_wrappers/test/test_feeds.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2024 Boston Dynamics AI Institute Inc.  All rights reserved.
 
+from typing import Optional
 
 import tf2_ros
 from geometry_msgs.msg import (
@@ -94,3 +95,31 @@ def test_adapted_message_feed(ros: ROSAwareScope) -> None:
     position_message = ensure(position_message_feed.latest)
     # no copies are expected, thus an identity check is valid
     assert position_message is expected_pose_message.pose.position
+
+
+def test_message_feed_recalls(ros: ROSAwareScope) -> None:
+    pose_message_feed = MessageFeed(SimpleFilter())
+
+    latest_message: Optional[PoseStamped] = None
+
+    def callback(message: PoseStamped) -> None:
+        nonlocal latest_message
+        latest_message = message
+
+    conn = pose_message_feed.recall(callback)
+
+    first_pose_message = PoseStamped()
+    first_pose_message.header.stamp.sec = 1
+    pose_message_feed.link.signalMessage(first_pose_message)
+
+    assert latest_message is not None
+    assert latest_message.header.stamp.sec == first_pose_message.header.stamp.sec
+
+    conn.close()
+
+    second_pose_message = PoseStamped()
+    second_pose_message.header.stamp.sec = 2
+    pose_message_feed.link.signalMessage(second_pose_message)
+
+    assert latest_message.header.stamp.sec != second_pose_message.header.stamp.sec
+    assert latest_message.header.stamp.sec == first_pose_message.header.stamp.sec


### PR DESCRIPTION
In some cases, a callback-based interface is still handy. This patch supports the corresponding idioms.