### PR TITLE
Add thread-safe message filters

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/feeds.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/feeds.py
@@ -3,12 +3,13 @@
 from typing import Any, Callable, Iterable, Iterator, List, Optional
 
 import tf2_ros
-from message_filters import ApproximateTimeSynchronizer, SimpleFilter
 from rclpy.node import Node
 from rclpy.task import Future
 
 import bdai_ros2_wrappers.scope as scope
-from bdai_ros2_wrappers.filters import SimpleAdapter, TransformFilter, Tunnel
+from bdai_ros2_wrappers.filters import (
+    Filter, Adapter, ApproximateTimeSynchronizer, TransformFilter, Tunnel
+)
 from bdai_ros2_wrappers.utilities import Tape
 
 
@@ -17,7 +18,7 @@ class MessageFeed:
 
     def __init__(
         self,
-        link: SimpleFilter,
+        link: Filter,
         *,
         history_length: Optional[int] = None,
         node: Optional[Node] = None,
@@ -39,7 +40,7 @@ class MessageFeed:
         node.context.on_shutdown(self._tape.close)
 
     @property
-    def link(self) -> SimpleFilter:
+    def link(self) -> Filter:
         """Gets the underlying message connection."""
         return self._link
 
@@ -129,7 +130,7 @@ class AdaptedMessageFeed(MessageFeed):
             kwargs: all other keyword arguments are forwarded
             for `MessageFeed` initialization.
         """
-        super().__init__(SimpleAdapter(feed.link, fn), **kwargs)
+        super().__init__(Adapter(feed.link, fn), **kwargs)
         self._feed = feed
 
     @property

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/feeds.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/feeds.py
@@ -7,9 +7,7 @@ from rclpy.node import Node
 from rclpy.task import Future
 
 import bdai_ros2_wrappers.scope as scope
-from bdai_ros2_wrappers.filters import (
-    Filter, Adapter, ApproximateTimeSynchronizer, TransformFilter, Tunnel
-)
+from bdai_ros2_wrappers.filters import Adapter, ApproximateTimeSynchronizer, Filter, TransformFilter, Tunnel
 from bdai_ros2_wrappers.utilities import Tape
 
 

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/filters.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/filters.py
@@ -5,10 +5,10 @@ import functools
 import itertools
 import threading
 from collections.abc import Sequence
-from typing import Any, Callable, Dict, Optional, Tuple, Protocol
+from typing import Any, Callable, Dict, Optional, Protocol, Tuple
 
-import tf2_ros
 import message_filters
+import tf2_ros
 from rclpy.duration import Duration
 from rclpy.node import Node
 from rclpy.task import Future
@@ -20,9 +20,11 @@ from bdai_ros2_wrappers.logging import RcutilsLogger
 class SimpleFilterProtocol(Protocol):
     """Protocol for `message_filters.SimpleFilter` subclasses."""
 
-    def registerCallback(self, callback: Callable, *args: Any) -> int: ...
+    def registerCallback(self, callback: Callable, *args: Any) -> int:
+        """Register callable to be called on filter output."""
 
-    def signalMessage(self, *messages: Any) -> None: ...
+    def signalMessage(self, *messages: Any) -> None:
+        """Feed one or more `messages` to the filter."""
 
 
 class Filter(SimpleFilterProtocol):
@@ -77,7 +79,9 @@ class Subscriber(Filter):
         """
         super().__init__()
         self.sub = node.create_subscription(
-            *args, callback=self.signalMessage, **kwargs
+            *args,
+            callback=self.signalMessage,
+            **kwargs,
         )
 
     def __getattr__(self, name: str) -> Any:

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/subscription.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/subscription.py
@@ -3,7 +3,6 @@
 from collections.abc import Sequence
 from typing import Any, Optional, Type, Union, cast
 
-from message_filters import ApproximateTimeSynchronizer, Subscriber
 from rclpy.callback_groups import CallbackGroup
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
@@ -11,6 +10,7 @@ from rclpy.task import Future
 
 import bdai_ros2_wrappers.scope as scope
 from bdai_ros2_wrappers.feeds import MessageFeed
+from bdai_ros2_wrappers.filters import ApproximateTimeSynchronizer, Subscriber
 from bdai_ros2_wrappers.futures import wait_for_future
 from bdai_ros2_wrappers.type_hints import Msg as MessageT
 

--- a/bdai_ros2_wrappers/test/test_feeds.py
+++ b/bdai_ros2_wrappers/test/test_feeds.py
@@ -8,7 +8,6 @@ from geometry_msgs.msg import (
     TransformStamped,
     TwistStamped,
 )
-from message_filters import SimpleFilter
 
 from bdai_ros2_wrappers.feeds import (
     AdaptedMessageFeed,
@@ -16,13 +15,14 @@ from bdai_ros2_wrappers.feeds import (
     MessageFeed,
     SynchronizedMessageFeed,
 )
+from bdai_ros2_wrappers.filters import Filter
 from bdai_ros2_wrappers.scope import ROSAwareScope
 from bdai_ros2_wrappers.utilities import ensure
 
 
 def test_framed_message_feed(ros: ROSAwareScope) -> None:
     tf_buffer = tf2_ros.Buffer()
-    pose_message_feed = MessageFeed(SimpleFilter())
+    pose_message_feed = MessageFeed(Filter())
     framed_message_feed = FramedMessageFeed(
         pose_message_feed,
         target_frame_id="map",
@@ -50,8 +50,8 @@ def test_framed_message_feed(ros: ROSAwareScope) -> None:
 
 
 def test_synchronized_message_feed(ros: ROSAwareScope) -> None:
-    pose_message_feed = MessageFeed(SimpleFilter())
-    twist_message_feed = MessageFeed(SimpleFilter())
+    pose_message_feed = MessageFeed(Filter())
+    twist_message_feed = MessageFeed(Filter())
     synchronized_message_feed = SynchronizedMessageFeed(
         pose_message_feed,
         twist_message_feed,
@@ -78,7 +78,7 @@ def test_synchronized_message_feed(ros: ROSAwareScope) -> None:
 
 
 def test_adapted_message_feed(ros: ROSAwareScope) -> None:
-    pose_message_feed = MessageFeed(SimpleFilter())
+    pose_message_feed = MessageFeed(Filter())
     position_message_feed = AdaptedMessageFeed(
         pose_message_feed,
         fn=lambda message: message.pose.position,
@@ -98,7 +98,7 @@ def test_adapted_message_feed(ros: ROSAwareScope) -> None:
 
 
 def test_message_feed_recalls(ros: ROSAwareScope) -> None:
-    pose_message_feed = MessageFeed(SimpleFilter())
+    pose_message_feed = MessageFeed(Filter())
 
     latest_message: Optional[PoseStamped] = None
 

--- a/bdai_ros2_wrappers/test/test_filters.py
+++ b/bdai_ros2_wrappers/test/test_filters.py
@@ -4,13 +4,12 @@ from typing import List, Tuple
 
 import tf2_ros
 from geometry_msgs.msg import PoseStamped, TransformStamped
-from message_filters import SimpleFilter
 
-from bdai_ros2_wrappers.filters import TransformFilter
+from bdai_ros2_wrappers.filters import Filter, TransformFilter
 
 
 def test_transform_wait() -> None:
-    source = SimpleFilter()
+    source = Filter()
     tf_buffer = tf2_ros.Buffer()
     tf_filter = TransformFilter(source, "map", tf_buffer, tolerance_sec=1.0)
     sink: List[Tuple[PoseStamped, TransformStamped]] = []
@@ -39,7 +38,7 @@ def test_transform_wait() -> None:
 
 
 def test_old_transform_filtering() -> None:
-    source = SimpleFilter()
+    source = Filter()
     tf_buffer = tf2_ros.Buffer()
     tf_filter = TransformFilter(source, "map", tf_buffer, tolerance_sec=2.0)
     sink: List[Tuple[PoseStamped, TransformStamped]] = []


### PR DESCRIPTION
Follow-up to #109. It turns out that upstream `message_filters` are not quite safe to use in multi-threaded applications (at least in Python). This patch introduces thread-safe equivalents that are API compatible with upstream ones.