### PR TITLE
Allow generalized method documentation

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/callables.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/callables.py
@@ -395,11 +395,7 @@ class GeneralizedMethod:
         bound_method = GeneralizedMethod.Bound(body, default_callable)
         setattr(instance, self.__attribute_name, bound_method)
 
-    def __get__(
-        self,
-        instance: Optional[Any],
-        owner: Optional[Type] = None,
-    ) -> Union["GeneralizedMethod", "GeneralizedMethod.Bound"]:
+    def __get__(self, instance: Optional[Any], owner: Optional[Type] = None) -> Any:
         if instance is None:
             return self
         return getattr(instance, self.__attribute_name)

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/callables.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/callables.py
@@ -356,6 +356,7 @@ class GeneralizedMethod:
 
     @property
     def transitional(self) -> bool:
+        """Check whether this method is transitional or not."""
         return self.legacy_overload is not None
 
     def legacy(self, func: Callable) -> Callable:

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/callables.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/callables.py
@@ -427,7 +427,7 @@ class GeneralizedMethodLike(Generic[P], GeneralizedMethod):
     ) -> Union["GeneralizedMethodLike[P]", "P"]:
         if instance is None:
             return self
-        return cast(P, getattr(instance, self.__attribute_name))
+        return cast(P, super().__get__(instance, owner))
 
 
 @overload
@@ -483,11 +483,18 @@ def generalized_method(
         transitional: a transitional method will stick to its
         prototype for default invocations.
     """
+    if spec is not None:
 
-    def __decorator(func: Callable) -> GeneralizedMethodLike[P]:
-        if spec is not None:
+        def __decorator_with_spec(func: Callable) -> GeneralizedMethodLike[P]:
+            assert spec is not None
             return spec(func, transitional)
-        return GeneralizedMethodLike[P](func, transitional)
+
+        if func is None:
+            return __decorator_with_spec
+        return __decorator_with_spec(func)
+
+    def __decorator(func: Callable) -> GeneralizedMethod:
+        return GeneralizedMethod(func, transitional)
 
     if func is None:
         return __decorator


### PR DESCRIPTION
This patch prepares the ground for proper documentation and type annotation of generalized methods. Specifically, it decouples method prototype and legacy implementation, and it enables protocol-based type annotations for these relatively complex devices.