### PR TITLE
Add py.typed marker

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/action_client.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
-from typing import Callable, Optional, Type
+from typing import Any, Callable, Optional, Type
 
 import rclpy.action
 from rclpy.node import Node
 
 import bdai_ros2_wrappers.scope as scope
 from bdai_ros2_wrappers.action_handle import ActionHandle
-from bdai_ros2_wrappers.type_hints import Action
 
 
 class ActionClientWrapper(rclpy.action.ActionClient):
@@ -14,7 +13,7 @@ class ActionClientWrapper(rclpy.action.ActionClient):
 
     def __init__(
         self,
-        action_type: Type[Action],
+        action_type: Type,
         action_name: str,
         node: Optional[Node] = None,
         wait_for_server: bool = True,
@@ -22,7 +21,7 @@ class ActionClientWrapper(rclpy.action.ActionClient):
         """Constructor
 
         Args:
-            action_type (Type[Action]): The type of the action
+            action_type (Type): The type of the action
             action_name (str): The name of the action (for logging purposes)
             node (Optional[Node]): optional node for action client, defaults to the current process node
             wait_for_server (bool): Whether to wait for the server
@@ -39,19 +38,19 @@ class ActionClientWrapper(rclpy.action.ActionClient):
     def send_goal_and_wait(
         self,
         action_name: str,
-        goal: Action.Goal,
+        goal: Optional[Any],
         timeout_sec: Optional[float] = None,
-    ) -> Optional[Action.Result]:
+    ) -> Optional[Any]:
         """Sends an action goal and waits for the result
 
         Args:
             action_name (str): A representative name of the action for logging
-            goal (Action.Goal): The Action Goal sent to the action server
+            goal (Any): The Action Goal sent to the action server
             timeout_sec (Optional[float]): A timeout for waiting on a response/result from the action server. Setting to
                 None creates no timeout
 
         Returns:
-            Optional[Action.Result]:
+            Optional[Any]:
         """
         if goal is None:
             self._node.get_logger.warn("Cannot send NULL ActionGoal")
@@ -84,10 +83,10 @@ class ActionClientWrapper(rclpy.action.ActionClient):
     def send_goal_async_handle(
         self,
         action_name: str,
-        goal: Action.Goal,
+        goal: Any,
         *,
-        result_callback: Optional[Callable[[Action.Result], None]] = None,
-        feedback_callback: Optional[Callable[[Action.Feedback], None]] = None,
+        result_callback: Optional[Callable[[Any], None]] = None,
+        feedback_callback: Optional[Callable[[Any], None]] = None,
         on_failure_callback: Optional[Callable[[], None]] = None,
     ) -> ActionHandle:
         """Sends an action goal asynchronously and create an `ActionHandle`
@@ -105,7 +104,11 @@ class ActionClientWrapper(rclpy.action.ActionClient):
         Returns:
             ActionHandle: An object to manage the asynchronous lifecycle of the action request
         """
-        handle = ActionHandle(action_name=action_name, logger=self._node.get_logger(), context=self._node.context)
+        handle = ActionHandle(
+            action_name=action_name,
+            logger=self._node.get_logger(),
+            context=self._node.context,
+        )
         if result_callback is not None:
             handle.set_result_callback(result_callback)
 

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/service_handle.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/service_handle.py
@@ -1,13 +1,11 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 import threading
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from rclpy.context import Context
 from rclpy.impl.rcutils_logger import RcutilsLogger
 from rclpy.task import Future
 from rclpy.utilities import get_default_context
-
-from bdai_ros2_wrappers.type_hints import SrvTypeResponse
 
 
 class ServiceHandle:
@@ -33,14 +31,14 @@ class ServiceHandle:
         context.on_shutdown(self._future_ready_event.set)
         self._result_callback: Optional[Callable] = None
         self._on_failure_callback: Optional[Callable] = None
-        self._result: Optional[SrvTypeResponse] = None
+        self._result: Optional[Any] = None
         if logger is None:
             self._logger = RcutilsLogger(name=f"{service_name} Handle")
         else:
             self._logger = logger
 
     @property
-    def result(self) -> Optional[SrvTypeResponse]:
+    def result(self) -> Optional[Any]:
         """Returns the result if one has been received from the service"""
         return self._result
 

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/single_goal_multiple_action_servers.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/single_goal_multiple_action_servers.py
@@ -8,7 +8,7 @@ from rclpy.callback_groups import CallbackGroup
 from rclpy.impl.rcutils_logger import RcutilsLogger
 from rclpy.node import Node
 
-from bdai_ros2_wrappers.type_hints import Action, ActionType
+from bdai_ros2_wrappers.type_hints import ActionType
 from bdai_ros2_wrappers.utilities import synchronized
 
 
@@ -66,7 +66,7 @@ class SingleGoalMultipleActionServers:
         for action_server in self._action_servers:
             action_server.destroy()
 
-    def goal_callback(self, goal: Action.Goal) -> GoalResponse:
+    def goal_callback(self, goal: Any) -> GoalResponse:
         """Accept or reject a client request to begin an action."""
         self.get_logger().info("Received goal request")
         return GoalResponse.ACCEPT

--- a/bdai_ros2_wrappers/setup.py
+++ b/bdai_ros2_wrappers/setup.py
@@ -8,6 +8,7 @@ setup(
     name=package_name,
     version="0.0.1",
     packages=[package_name],
+    package_data={package_name: ["py.typed"]},
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
         ("share/" + package_name, ["package.xml"]),

--- a/bdai_ros2_wrappers/test/test_action_handle.py
+++ b/bdai_ros2_wrappers/test/test_action_handle.py
@@ -12,7 +12,6 @@ from rclpy.node import Node
 
 from bdai_ros2_wrappers.action_handle import ActionHandle
 from bdai_ros2_wrappers.scope import ROSAwareScope
-from bdai_ros2_wrappers.type_hints import Action
 
 
 def _default_execute_callback(goal_handle: ServerGoalHandle) -> Fibonacci.Result:
@@ -64,7 +63,7 @@ def _execute_callback_slowly(goal_handle: ServerGoalHandle) -> Fibonacci.Result:
     return _default_execute_callback(goal_handle)
 
 
-def _goal_callback_reject(goal: Action.Goal) -> GoalResponse:
+def _goal_callback_reject(goal: Any) -> GoalResponse:
     return GoalResponse.REJECT
 
 
@@ -111,7 +110,7 @@ class ActionHandleMocks:
 
 def do_send_goal(
     action_client: ActionClient,
-    goal: Action.Goal,
+    goal: Any,
     label: Optional[str] = None,
 ) -> Tuple[ActionHandle, ActionHandleMocks]:
     if label is None:

--- a/bdai_ros2_wrappers/test/test_filters.py
+++ b/bdai_ros2_wrappers/test/test_filters.py
@@ -13,7 +13,7 @@ def test_transform_wait() -> None:
     tf_buffer = tf2_ros.Buffer()
     tf_filter = TransformFilter(source, "map", tf_buffer, tolerance_sec=1.0)
     sink: List[Tuple[PoseStamped, TransformStamped]] = []
-    tf_filter.registerCallback(lambda *msgs: sink.append(msgs))
+    tf_filter.registerCallback(lambda *msgs: sink.append((msgs[0], msgs[1])))
     assert len(sink) == 0
     pose_message = PoseStamped()
     pose_message.header.frame_id = "odom"
@@ -42,7 +42,7 @@ def test_old_transform_filtering() -> None:
     tf_buffer = tf2_ros.Buffer()
     tf_filter = TransformFilter(source, "map", tf_buffer, tolerance_sec=2.0)
     sink: List[Tuple[PoseStamped, TransformStamped]] = []
-    tf_filter.registerCallback(lambda *msgs: sink.append(msgs))
+    tf_filter.registerCallback(lambda *msgs: sink.append((msgs[0], msgs[1])))
     assert len(sink) == 0
     first_pose_message = PoseStamped()
     first_pose_message.header.frame_id = "odom"

--- a/bdai_ros2_wrappers/test/test_service_handle.py
+++ b/bdai_ros2_wrappers/test/test_service_handle.py
@@ -76,7 +76,7 @@ def test_failed_trigger(ros: ROSAwareScope) -> None:
     assert result.message == "bar"
 
 
-def setbool_service_callback(req: SrvTypeRequest, resp: SrvTypeResponse) -> SrvTypeResponse:
+def setbool_service_callback(req: SetBool.Request, resp: SetBool.Response) -> SetBool.Response:
     result = SetBool.Response()
     if req.data:
         result.success = True


### PR DESCRIPTION
Precisely what the title says. This patch installs the `py.typed` marker along with `bdai_ros2_wrappers`, and fixes typing annotations that start to fail.