### PR TITLE
Add type annotations to ergonomic wrappers

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/subscription.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/subscription.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute Inc.  All rights reserved.
 
 from collections.abc import Sequence
-from typing import Any, Optional, Type, Union, cast
+from typing import Any, Optional, Type, TypeVar, Union, cast
 
 from rclpy.callback_groups import CallbackGroup
 from rclpy.node import Node
@@ -11,11 +11,12 @@ from rclpy.task import Future
 import bdai_ros2_wrappers.scope as scope
 from bdai_ros2_wrappers.feeds import MessageFeed
 from bdai_ros2_wrappers.filters import ApproximateTimeSynchronizer, Subscriber
-from bdai_ros2_wrappers.futures import wait_for_future
-from bdai_ros2_wrappers.type_hints import Msg as MessageT
+from bdai_ros2_wrappers.futures import FutureLike, wait_for_future
+
+MessageT = TypeVar("MessageT")
 
 
-class Subscription(MessageFeed):
+class Subscription(MessageFeed[MessageT]):
     """An ergonomic interface for topic subscriptions in ROS 2.
 
     Subscription instances are `MessageFeed` instances wrapping `message_filters.Subscriber`
@@ -141,7 +142,7 @@ def wait_for_message_async(
     *,
     qos_profile: Union[QoSProfile, int] = 1,
     node: Optional[Node] = None,
-) -> Future:
+) -> FutureLike[MessageT]:
     """Wait for message on a given topic asynchronously.
 
     Args:
@@ -204,7 +205,7 @@ def wait_for_message(
 
 def wait_for_messages(
     topic_names: Sequence[str],
-    message_types: Sequence[MessageT],
+    message_types: Sequence[Type],
     *,
     timeout_sec: Optional[float] = None,
     node: Optional[Node] = None,
@@ -240,7 +241,7 @@ def wait_for_messages(
 
 def wait_for_messages_async(
     topic_names: Sequence[str],
-    message_types: Sequence[MessageT],
+    message_types: Sequence[Type],
     *,
     queue_size: int = 10,
     delay: float = 0.2,
@@ -248,7 +249,7 @@ def wait_for_messages_async(
     node: Optional[Node] = None,
     qos_profiles: Optional[Sequence[Optional[QoSProfile]]] = None,
     callback_group: Optional[CallbackGroup] = None,
-) -> Future:
+) -> FutureLike[Sequence[Any]]:
     """Asynchronous version of wait_for_messages
 
     Args:

--- a/bdai_ros2_wrappers/test/test_action.py
+++ b/bdai_ros2_wrappers/test/test_action.py
@@ -49,9 +49,12 @@ def default_execute_callback(goal_handle: ServerGoalHandle) -> Fibonacci.Result:
     return result
 
 
+FibonacciActionable = Actionable[Fibonacci.Goal, Fibonacci.Result, Fibonacci.Feedback]
+
+
 def test_successful_synchronous_action_invocation(ros: ROSAwareScope) -> None:
     ActionServer(ros.node, Fibonacci, "fibonacci/compute", default_execute_callback)
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
     result = compute_fibonacci(Fibonacci.Goal(order=5), timeout_sec=10.0)
     expected_result = array.array("i", [0, 1, 1, 2, 3, 5])
@@ -60,7 +63,7 @@ def test_successful_synchronous_action_invocation(ros: ROSAwareScope) -> None:
 
 def test_successful_synchronous_composed_action_invocation(ros: ROSAwareScope) -> None:
     ActionServer(ros.node, Fibonacci, "fibonacci/compute", default_execute_callback)
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     compute_fibonacci_sequences = compute_fibonacci.vectorized.compose(
         lambda n: (Fibonacci.Goal(order=i) for i in range(n + 1)),
     )
@@ -80,7 +83,7 @@ def test_successful_synchronous_composed_action_invocation(ros: ROSAwareScope) -
 def test_successful_synchronous_action_invocation_with_feedback(ros: ROSAwareScope) -> None:
     mock_callback = Mock()
     ActionServer(ros.node, Fibonacci, "fibonacci/compute", default_execute_callback)
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
     result = compute_fibonacci(Fibonacci.Goal(order=5), feedback_callback=mock_callback, timeout_sec=10.0)
     expected_result = array.array("i", [0, 1, 1, 2, 3, 5])
@@ -90,7 +93,7 @@ def test_successful_synchronous_action_invocation_with_feedback(ros: ROSAwareSco
 
 def test_successful_asynchronous_action_invocation(ros: ROSAwareScope) -> None:
     ActionServer(ros.node, Fibonacci, "fibonacci/compute", default_execute_callback)
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
     action = compute_fibonacci.asynchronously(Fibonacci.Goal(order=5))
     assert wait_for_future(action.finalization, timeout_sec=10.0)
@@ -107,7 +110,7 @@ def test_successful_asynchronous_action_invocation(ros: ROSAwareScope) -> None:
 
 def test_successful_asynchronous_composed_action_invocation(ros: ROSAwareScope) -> None:
     ActionServer(ros.node, Fibonacci, "fibonacci/compute", default_execute_callback)
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     compute_fibonacci_sequences = compute_fibonacci.vectorized.compose(
         lambda n: (Fibonacci.Goal(order=i) for i in range(n + 1)),
     )
@@ -130,7 +133,7 @@ def test_spin_on_succesful_asynchronous_action_invocation() -> None:
         SingleThreadedExecutor(),
     ) as ros.executor, ros.managed(Node, node_name="test_node") as ros.node:
         ActionServer(ros.node, Fibonacci, "fibonacci/compute", default_execute_callback)
-        compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+        compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
         assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
         action = compute_fibonacci.asynchronously(Fibonacci.Goal(order=5))
         ros.executor.spin_until_future_complete(action.as_future(), timeout_sec=10.0)
@@ -139,7 +142,7 @@ def test_spin_on_succesful_asynchronous_action_invocation() -> None:
 
 def test_successful_asynchronous_action_invocation_with_feedback(ros: ROSAwareScope) -> None:
     ActionServer(ros.node, Fibonacci, "fibonacci/compute", default_execute_callback)
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
     action = compute_fibonacci.asynchronously(Fibonacci.Goal(order=5), track_feedback=True)
     assert wait_for_future(action.acknowledgement, timeout_sec=10.0)
@@ -179,7 +182,7 @@ def test_successful_asynchronous_action_invocation_with_forward_feedback(ros: RO
         return result
 
     ActionServer(ros.node, Fibonacci, "fibonacci/compute", execute_callback)
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
     action = compute_fibonacci.asynchronously(Fibonacci.Goal(order=1), track_feedback=True)
     assert wait_for_future(action.acknowledgement, timeout_sec=10.0)
@@ -201,7 +204,7 @@ def test_successful_asynchronous_action_invocation_with_forward_feedback(ros: RO
 
 def test_successful_asynchronous_action_invocation_with_limited_feedback(ros: ROSAwareScope) -> None:
     ActionServer(ros.node, Fibonacci, "fibonacci/compute", default_execute_callback)
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
     action = compute_fibonacci.asynchronously(Fibonacci.Goal(order=5), track_feedback=1)
     assert wait_for_future(action.acknowledgement, timeout_sec=10.0)
@@ -226,7 +229,7 @@ def test_successful_asynchronous_action_invocation_with_ephemeral_feedback(ros: 
         return default_execute_callback(goal_handle)
 
     ActionServer(ros.node, Fibonacci, "fibonacci/compute", synchronized_execute_callback)
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
     action = compute_fibonacci.asynchronously(Fibonacci.Goal(order=5), track_feedback=0)
     assert wait_for_future(action.acknowledgement, timeout_sec=10.0)
@@ -251,7 +254,7 @@ def test_rejected_synchronous_action_invocation(ros: ROSAwareScope) -> None:
         default_execute_callback,
         goal_callback=lambda _: GoalResponse.REJECT,
     )
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
     goal = Fibonacci.Goal(order=5)
     assert compute_fibonacci(goal, nothrow=True, timeout_sec=10.0) is None
@@ -268,7 +271,7 @@ def test_rejected_asynchronous_action_invocation(ros: ROSAwareScope) -> None:
         default_execute_callback,
         goal_callback=lambda _: GoalResponse.REJECT,
     )
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
     action = compute_fibonacci.asynchronously(Fibonacci.Goal(order=5))
     assert wait_for_future(action.finalization, timeout_sec=10.0)
@@ -286,7 +289,7 @@ def test_aborted_synchronous_action_invocation(ros: ROSAwareScope) -> None:
         return Fibonacci.Result()
 
     ActionServer(ros.node, Fibonacci, "fibonacci/compute", execute_callback)
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
     goal = Fibonacci.Goal(order=5)
     result = compute_fibonacci(goal, nothrow=True, timeout_sec=10.0)
@@ -305,7 +308,7 @@ def test_aborted_asynchronous_action_invocation(ros: ROSAwareScope) -> None:
         return Fibonacci.Result()
 
     ActionServer(ros.node, Fibonacci, "fibonacci/compute", execute_callback)
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
     action = compute_fibonacci.asynchronously(Fibonacci.Goal(order=5))
     assert wait_for_future(action.finalization, timeout_sec=10.0)
@@ -333,7 +336,7 @@ def test_cancelled_synchronous_action_invocation(ros: ROSAwareScope) -> None:
         execute_callback,
         cancel_callback=lambda _: CancelResponse.ACCEPT,
     )
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
 
     assert ros.node is not None
@@ -372,7 +375,7 @@ def test_cancelled_asynchronous_action_invocation(ros: ROSAwareScope) -> None:
         execute_callback,
         cancel_callback=lambda _: CancelResponse.ACCEPT,
     )
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
     assert compute_fibonacci.wait_for_server(timeout_sec=2.0)
     action = compute_fibonacci.asynchronously(Fibonacci.Goal(order=5))
     assert wait_for_future(action.acknowledgement, timeout_sec=10.0)

--- a/bdai_ros2_wrappers/test/test_executors.py
+++ b/bdai_ros2_wrappers/test/test_executors.py
@@ -40,12 +40,12 @@ def test_autoscaling_thread_pool() -> None:
     """Asserts that the autoscaling thread pool scales and de-scales on demand."""
     with AutoScalingThreadPool(max_idle_time=2.0) as pool:
         assert len(pool.workers) == 0
-        assert not pool.working
+        assert not bool(pool.working)
 
         events = [threading.Event() for _ in range(10)]
         results = pool.map(lambda i, e: e.wait() and i, range(10), events)
         assert len(pool.workers) == len(events)
-        assert pool.working
+        assert bool(pool.working)
         assert not pool.capped
 
         for e in events:
@@ -57,7 +57,7 @@ def test_autoscaling_thread_pool() -> None:
 
         with pool.scaling_event:
             assert pool.scaling_event.wait_for(predicate, timeout=10)
-        assert not pool.working
+        assert not bool(pool.working)
 
 
 def test_autoscaling_thread_pool_checks_arguments() -> None:
@@ -92,12 +92,12 @@ def test_autoscaling_thread_pool_with_limits() -> None:
     """Asserts that the autoscaling thread pool enforces the user-defined range on the number of workers."""
     with AutoScalingThreadPool(min_workers=2, max_workers=5, max_idle_time=0.1) as pool:
         assert len(pool.workers) == 2
-        assert not pool.working
+        assert bool(not pool.working)
 
         events = [threading.Event() for _ in range(10)]
         results = pool.map(lambda i, e: e.wait() and i, range(10), events)
         assert len(pool.workers) == 5
-        assert pool.working
+        assert bool(pool.working)
 
         for e in events:
             e.set()
@@ -115,12 +115,12 @@ def test_autoscaling_thread_pool_with_quota() -> None:
     """Asserts that the autoscaling thread pool respects submission quotas."""
     with AutoScalingThreadPool(submission_quota=5, submission_patience=1.0, max_idle_time=2.0) as pool:
         assert len(pool.workers) == 0
-        assert not pool.working
+        assert not bool(pool.working)
 
         events = [threading.Event() for _ in range(10)]
         results = pool.map(lambda i, e: e.wait() and i, range(10), events)
         assert len(pool.workers) == 5
-        assert pool.working
+        assert bool(pool.working)
         assert pool.capped
 
         for e in events[:5]:

--- a/bdai_ros2_wrappers/test/test_node.py
+++ b/bdai_ros2_wrappers/test/test_node.py
@@ -54,7 +54,7 @@ def test_node_destruction_during_execution(ros_context: Context) -> None:
         # Then queue node destruction
         executor.create_task(lambda: node.destroy_node())
         executor.spin_once()
-        assert not node.destruction_requested  # still queued
+        assert not bool(node.destruction_requested)  # still queued
         # Then queue another service invocation
         future = client.call_async(Trigger.Request())
         executor.spin_once()

--- a/bdai_ros2_wrappers/test/test_service.py
+++ b/bdai_ros2_wrappers/test/test_service.py
@@ -17,7 +17,7 @@ def succeeding_callback(request: Trigger.Request, response: Trigger.Response) ->
 def test_successful_synchronous_service_invocation(ros: ROSAwareScope) -> None:
     assert ros.node is not None
     ros.node.create_service(Trigger, "trigger_something", succeeding_callback)
-    trigger_something = Serviced(Trigger, "trigger_something")
+    trigger_something: Serviced[Trigger.Request, Trigger.Response] = Serviced(Trigger, "trigger_something")
     response = trigger_something(timeout_sec=5.0)
     assert response.success
 
@@ -25,7 +25,7 @@ def test_successful_synchronous_service_invocation(ros: ROSAwareScope) -> None:
 def test_successful_asynchronous_service_invocation(ros: ROSAwareScope) -> None:
     assert ros.node is not None
     ros.node.create_service(Trigger, "trigger_something", succeeding_callback)
-    trigger_something = Serviced(Trigger, "trigger_something")
+    trigger_something: Serviced[Trigger.Request, Trigger.Response] = Serviced(Trigger, "trigger_something")
     service = trigger_something.asynchronously()
     assert wait_for_future(service, timeout_sec=5.0)
     response = service.result()
@@ -42,7 +42,7 @@ def test_timed_out_synchronous_service_invocation(ros: ROSAwareScope) -> None:
         return response
 
     ros.node.create_service(Trigger, "trigger_something", callback)
-    trigger_something = Serviced(Trigger, "trigger_something")
+    trigger_something: Serviced[Trigger.Request, Trigger.Response] = Serviced(Trigger, "trigger_something")
     with pytest.raises(ServiceTimeout):
         trigger_something(timeout_sec=0.01)
 
@@ -55,7 +55,7 @@ def failing_callback(request: Trigger.Request, response: Trigger.Response) -> Tr
 def test_failing_synchronous_service_invocation(ros: ROSAwareScope) -> None:
     assert ros.node is not None
     ros.node.create_service(Trigger, "trigger_something", failing_callback)
-    trigger_something = Serviced(Trigger, "trigger_something")
+    trigger_something: Serviced[Trigger.Request, Trigger.Response] = Serviced(Trigger, "trigger_something")
     response = trigger_something(nothrow=True, timeout_sec=5.0)
     assert not response.success
     with pytest.raises(ServiceError) as exc:
@@ -67,7 +67,7 @@ def test_failing_synchronous_service_invocation(ros: ROSAwareScope) -> None:
 def test_failing_asynchronous_service_invocation(ros: ROSAwareScope) -> None:
     assert ros.node is not None
     ros.node.create_service(Trigger, "trigger_something", failing_callback)
-    trigger_something = Serviced(Trigger, "trigger_something")
+    trigger_something: Serviced[Trigger.Request, Trigger.Response] = Serviced(Trigger, "trigger_something")
     service = trigger_something.asynchronously()
     assert wait_for_future(service, timeout_sec=5.0)
     response = service.result()

--- a/bdai_ros2_wrappers/test/test_service_handle.py
+++ b/bdai_ros2_wrappers/test/test_service_handle.py
@@ -1,20 +1,19 @@
 #  Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 import inspect
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple, Type
 
 from rclpy.client import Client
 from std_srvs.srv import Empty, SetBool, Trigger
 
 from bdai_ros2_wrappers.scope import ROSAwareScope
 from bdai_ros2_wrappers.service_handle import ServiceHandle
-from bdai_ros2_wrappers.type_hints import SrvTypeRequest, SrvTypeResponse
 
 
 def do_request(
     client: Client,
-    request: SrvTypeRequest,
+    request: Type,
     label: Optional[str] = None,
-) -> Tuple[bool, Optional[SrvTypeResponse]]:
+) -> Tuple[bool, Optional[Any]]:
     if label is None:
         label = inspect.stack()[1].function
     assert client.wait_for_service(timeout_sec=1.0)
@@ -38,7 +37,7 @@ def do_request(
 def test_successful_trigger(ros: ROSAwareScope) -> None:
     """Request a successful trigger. Should return a success condition with the message foo."""
 
-    def callback(req: SrvTypeRequest, resp: SrvTypeResponse) -> SrvTypeResponse:
+    def callback(req: Trigger.Request, resp: Trigger.Response) -> Trigger.Response:
         result = Trigger.Response()
         result.success = True
         result.message = "foo"
@@ -58,7 +57,7 @@ def test_successful_trigger(ros: ROSAwareScope) -> None:
 def test_failed_trigger(ros: ROSAwareScope) -> None:
     """Request a failed trigger. Should return a success condition with the message bar."""
 
-    def callback(req: SrvTypeRequest, resp: SrvTypeResponse) -> SrvTypeResponse:
+    def callback(req: Trigger.Request, resp: Trigger.Response) -> Trigger.Response:
         result = Trigger.Response()
         result.success = False
         result.message = "bar"
@@ -116,7 +115,7 @@ def test_failed_set_bool(ros: ROSAwareScope) -> None:
 def test_warning(ros: ROSAwareScope) -> None:
     """Tests that the result callback should give a warning and have no fields."""
 
-    def callback(req: SrvTypeRequest, resp: SrvTypeResponse) -> SrvTypeResponse:
+    def callback(req: Empty.Request, resp: Empty.Response) -> Empty.Response:
         return Empty.Response()
 
     assert ros.node is not None

--- a/bdai_ros2_wrappers/test/test_single_goal_multiple_action_servers.py
+++ b/bdai_ros2_wrappers/test/test_single_goal_multiple_action_servers.py
@@ -68,8 +68,9 @@ def action_triplet(ros: ROSAwareScope) -> Iterable[Tuple[Barrier, Actionable, Ac
     ]
     assert ros.node is not None
     SingleGoalMultipleActionServers(ros.node, action_parameters, nosync=True)
-    compute_fibonacci = Actionable(Fibonacci, "fibonacci/compute", ros.node)
-    compute_fibonacci_reversed = Actionable(Fibonacci, "fibonacci/compute_reversed", ros.node)
+    FibonacciActionable = Actionable[Fibonacci.Goal, Fibonacci.Result, Fibonacci.Feedback]
+    compute_fibonacci: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute", ros.node)
+    compute_fibonacci_reversed: FibonacciActionable = Actionable(Fibonacci, "fibonacci/compute_reversed", ros.node)
 
     try:
         yield barrier, compute_fibonacci, compute_fibonacci_reversed

--- a/bdai_ros2_wrappers/test/test_subscription.py
+++ b/bdai_ros2_wrappers/test/test_subscription.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Boston Dynamics AI Institute Inc.  All rights reserved.
 import itertools
 import time
-from typing import Any, Iterator
+from typing import Any, Iterator, cast
 
 from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile
 from std_msgs.msg import Int8, String
@@ -61,7 +61,7 @@ def test_subscription_future_wait(ros: ROSAwareScope) -> None:
     pub.publish(Int8(data=1))
 
     assert wait_for_future(sequence.update, timeout_sec=5.0)
-    assert ensure(sequence.latest).data == 1
+    assert cast(Int8, ensure(sequence.latest)).data == 1
 
 
 def test_subscription_matching_future_wait(ros: ROSAwareScope) -> None:
@@ -155,7 +155,7 @@ def test_subscription_cancelation(ros: ROSAwareScope) -> None:
     assert len(historic_numbers) == 1
     assert historic_numbers[0] == 1
 
-    assert ensure(sequence.latest).data == 1
+    assert cast(Int8, ensure(sequence.latest)).data == 1
 
 
 def test_wait_for_messages(ros: ROSAwareScope) -> None:


### PR DESCRIPTION
Precisely what the title says. This patch type annotates all three (3) ergonomic wrappers for ROS 2 interfaces: `Subscription`, `Serviced`, and `Actionable`.