### PR TITLE
Export implicit `proto2ros_vendor_package()` dependencies

### DIFF
--- a/proto2ros/cmake/proto2ros_vendor_package.cmake
+++ b/proto2ros/cmake/proto2ros_vendor_package.cmake
@@ -120,5 +120,6 @@ macro(proto2ros_vendor_package target)
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
+  ament_export_dependencies(builtin_interfaces proto2ros rclcpp)
   ament_export_targets(${PROJECT_NAME})
 endmacro()


### PR DESCRIPTION
Follow-up to #120. This one went completely over my head.