### PR TITLE
Allow `proto2ros_generate()` to depend on `protobuf_generate()`

### DIFF
--- a/proto2ros/cmake/proto2ros_generate.cmake
+++ b/proto2ros/cmake/proto2ros_generate.cmake
@@ -25,7 +25,7 @@ function(proto2ros_generate target)
   cmake_parse_arguments(
     ARG "NO_LINT"
     "PACKAGE_NAME;CONFIG_FILE;INTERFACES_OUT_VAR;PYTHON_OUT_VAR;CPP_OUT_VAR;INCLUDE_OUT_VAR"
-    "PROTOS;PROTO_DESCRIPTORS;IMPORT_DIRS;CONFIG_OVERLAYS;APPEND_PYTHONPATH" ${ARGN})
+    "PROTOS;PROTO_DESCRIPTORS;IMPORT_DIRS;CONFIG_OVERLAYS;APPEND_PYTHONPATH;DEPENDS" ${ARGN})
   if(NOT ARG_PACKAGE_NAME)
     set(ARG_PACKAGE_NAME ${PROJECT_NAME})
   endif()
@@ -138,7 +138,7 @@ function(proto2ros_generate target)
       ${PYTHON_EXECUTABLE} -m proto2ros.cli.generate ${PROTO2ROS_GENERATE_OPTIONS} ${ARG_PACKAGE_NAME} ${PROTO_DESCRIPTORS}
     COMMAND ${CMAKE_COMMAND} -E compare_files "${OUTPUT_PATH}/manifest.txt" "${OUTPUT_PATH}/manifest.orig.txt"
     COMMENT "Generate Protobuf <-> ROS interop interfaces (must reconfigure if the cardinality of the output set changes)"
-    DEPENDS ${PROTO_DESCRIPTORS}
+    DEPENDS ${PROTO_DESCRIPTORS} ${ARG_DEPENDS}
     VERBATIM
   )
   add_custom_target(${target} DEPENDS ${output_files})

--- a/proto2ros/cmake/proto2ros_vendor_package.cmake
+++ b/proto2ros/cmake/proto2ros_vendor_package.cmake
@@ -15,7 +15,11 @@
 macro(proto2ros_vendor_package target)
   set(options NO_LINT)
   set(one_value_keywords PACKAGE_NAME)
-  set(multi_value_keywords PROTOS IMPORT_DIRS CONFIG_OVERLAYS ROS_DEPENDENCIES CPP_DEPENDENCIES CPP_INCLUDES CPP_SOURCES PYTHON_MODULES PYTHON_PACKAGES)
+  set(
+    multi_value_keywords
+    PROTOS IMPORT_DIRS CONFIG_OVERLAYS ROS_DEPENDENCIES CPP_DEPENDENCIES
+    CPP_INCLUDES CPP_SOURCES PYTHON_MODULES PYTHON_PACKAGES DEPENDS
+  )
   cmake_parse_arguments(ARG "${options}" "${one_value_keywords}" "${multi_value_keywords}" ${ARGN})
 
   if(NOT ARG_PACKAGE_NAME)
@@ -42,6 +46,9 @@ macro(proto2ros_vendor_package target)
   set(proto2ros_generate_OPTIONS)
   if(ARG_NO_LINT)
     list(APPEND proto2ros_generate_OPTIONS NO_LINT)
+  endif()
+  if(ARG_DEPENDS)
+    list(APPEND proto2ros_generate_OPTIONS DEPENDS ${ARG_DEPENDS})
   endif()
 
   proto2ros_generate(

--- a/proto2ros_tests/CMakeLists.txt
+++ b/proto2ros_tests/CMakeLists.txt
@@ -45,9 +45,7 @@ proto2ros_generate(
   CPP_OUT_VAR cpp_sources
   INCLUDE_OUT_VAR cpp_include_dir
   APPEND_PYTHONPATH "${PROTO_OUT_DIR}"
-)
-add_dependencies(
-  ${PROJECT_NAME}_messages_gen ${PROJECT_NAME}_proto_gen
+  DEPENDS ${PROJECT_NAME}_proto_gen
 )
 
 rosidl_generate_interfaces(


### PR DESCRIPTION
Precisely what the title says. Also fixes a race in `proto2ros_tests` as a result of failing to establish this dependency.