### PR TITLE
Update `proto2ros` CMake macros documentation

### DIFF
--- a/proto2ros/cmake/proto2ros_generate.cmake
+++ b/proto2ros/cmake/proto2ros_generate.cmake
@@ -18,6 +18,12 @@
 #   Defaults to the target name with an `_interfaces` suffix.
 # :param PYTHON_OUT_VAR: the name of the variable to yield generated Python sources.
 #   Defaults to the target name with a `_python_sources` suffix.
+# :param CPP_OUT_VAR: the name of the variable to yield generated C++ sources
+#   (both .cpp and .hpp files). Defaults to the target name with a `_cpp_sources` suffix.
+# :param INCLUDE_OUT_VAR: the name of the variable to yield the path to generated
+#   C++ includes. Defaults to the target name with a `_cpp_include` suffix.
+# :param DEPENDS: optional, additional dependencies to the generation command.
+#   This can be useful to depend on earlier protobuf_generate() commands.
 # :param APPEND_PYTHONPATH: optional paths to append to the PYTHONPATH that applies
 #   to the generation process.
 # :param NO_LINT: if provided, no lint tests are added for generated code.

--- a/proto2ros/cmake/proto2ros_vendor_package.cmake
+++ b/proto2ros/cmake/proto2ros_vendor_package.cmake
@@ -11,7 +11,24 @@
 #   are provided. If none is given, parent directories of PROTOS are used instead.
 # :param CONFIG_OVERLAYS: optional configuration file overlays to be applied sequentially
 #   over the default base configuration file.
-#
+# :param ROS_DEPENDENCIES: optional ROS package name to depend on for message generation and builds.
+# :param CPP_DEPENDENCIES: optional C++ targets to depend on for library builds.
+# :param CPP_INCLUDES: optional, additional C++ includes to use when building C++ sources.
+#   If nont is provided and ${CMAKE_CURRENT_SOURCE_DIR}/include/${ARG_PACKAGE_NAME} exists
+#   as a directory, then it will be picked up by default.
+# :param CPP_SOURCES: optional, additional C++ sources to build alongside generated C++ sources.
+#   If none is provided and both ${CMAKE_CURRENT_SOURCE_DIR}/include/${ARG_PACKAGE_NAME} and
+#   ${CMAKE_CURRENT_SOURCE_DIR}/src exist as directories, then source files matching either
+#   ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc or ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp glob
+#   expressions will be picked up by default.
+# :param PYTHON_MODULES: optional, additional Python module sources to install
+#   alongside generated Python modules.
+# :param PYTHON_PACKAGES: optional, additional Python packages to install alongside
+#   generated Python packages. If none is provided and one is found under the
+#   ${CMAKE_CURRENT_SOURCE_DIR}/${PACKAGE_NAME}, it will be picked up by default.
+# :param DEPENDS: optional, additional dependencies to the generation command.
+#   This can be useful to depend on earlier protobuf_generate() commands.
+# :param NO_LINT: if provided, no lint tests are added for generated code.
 macro(proto2ros_vendor_package target)
   set(options NO_LINT)
   set(one_value_keywords PACKAGE_NAME)

--- a/proto2ros/cmake/proto2ros_vendor_package.cmake
+++ b/proto2ros/cmake/proto2ros_vendor_package.cmake
@@ -14,7 +14,7 @@
 # :param ROS_DEPENDENCIES: optional ROS package name to depend on for message generation and builds.
 # :param CPP_DEPENDENCIES: optional C++ targets to depend on for library builds.
 # :param CPP_INCLUDES: optional, additional C++ includes to use when building C++ sources.
-#   If nont is provided and ${CMAKE_CURRENT_SOURCE_DIR}/include/${ARG_PACKAGE_NAME} exists
+#   If none is provided and ${CMAKE_CURRENT_SOURCE_DIR}/include/${ARG_PACKAGE_NAME} exists
 #   as a directory, then it will be picked up by default.
 # :param CPP_SOURCES: optional, additional C++ sources to build alongside generated C++ sources.
 #   If none is provided and both ${CMAKE_CURRENT_SOURCE_DIR}/include/${ARG_PACKAGE_NAME} and


### PR DESCRIPTION
Follow-up to #118. I noticed CMake macro documentation was a bit outdated. This patch amends this.