### PR TITLE
`MessageFeed.latest_update` for simple race-free waits

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/feeds.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/feeds.py
@@ -75,6 +75,11 @@ class MessageFeed(Generic[MessageT]):
         return self._tape.head
 
     @property
+    def latest_update(self) -> FutureLike[MessageT]:
+        """Gets the future to the latest message, which may not have been received yet."""
+        return self._tape.latest_write
+
+    @property
     def update(self) -> FutureLike[MessageT]:
         """Gets the future to the next message yet to be received."""
         return self._tape.future_write

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/utilities.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/utilities.py
@@ -170,6 +170,23 @@ class Tape(Generic[T]):
         self._closed = False
 
     @property
+    def latest_write(self) -> FutureLike[T]:
+        """Gets the future to the latest data written or to be written."""
+        with self._lock:
+            if self._content is None:
+                raise RuntimeError("zero-length tape only writes forward")
+            if len(self._content) > 0:
+                data = self._content[-1]
+                latest_write = Future()
+                latest_write.set_result(data)
+                return latest_write
+            if self._future_write is None:
+                self._future_write = Future()
+                if self._closed:
+                    self._future_write.cancel()
+            return self._future_write
+
+    @property
     def future_write(self) -> FutureLike[T]:
         """Gets the future to the next data yet to be written."""
         with self._lock:

--- a/bdai_ros2_wrappers/test/test_utilities.py
+++ b/bdai_ros2_wrappers/test/test_utilities.py
@@ -71,6 +71,33 @@ def test_tape_drops_unused_streams() -> None:
     assert len(tape._streams) == 0
 
 
+def test_tape_future_writes() -> None:
+    tape: Tape[int] = Tape()
+    tape.write(0)
+    future = tape.future_write
+    assert not future.done()
+    tape.write(1)
+    assert future.done()
+    assert future.result() == 1
+    tape.close()
+    future = tape.future_write
+    assert future.cancelled()
+
+
+def test_tape_latest_writes() -> None:
+    tape: Tape[int] = Tape()
+    assert tape.head is None
+    future = tape.latest_write
+    assert not future.done()
+    tape.write(0)
+    assert tape.head == 0
+    assert future.done()
+    assert future.result() == tape.head
+    future = tape.latest_write
+    assert future.done()
+    assert future.result() == tape.head
+
+
 def test_either_or() -> None:
     assert either_or(None, "value", True)
     data = argparse.Namespace(value=True)


### PR DESCRIPTION
`MessageFeed.latest` yields what's available in buffers and `MessageFeed.update` can be used to wait for what comes next, but neither helps the common wait-for-a-message use case. This is particularly bad for message feeds tied to transient local ROS 2 topic subscriptions, as both race with a single message dispatch.

Thus, this patch adds `MessageFeed.latest_update` to cover for this.