### PR TITLE
Fix `synchros2` aliasing as `bdai_ros2_wrappers`

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/__init__.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/__init__.py
@@ -1,5 +1,19 @@
 # Copyright (c) 2024 Boston Dynamics AI Institute Inc.  All rights reserved.
 
+import importlib
+import pkgutil
 import sys
 
-sys.modules[__name__] = __import__("synchros2")
+
+def aliased_import(name, alias):
+    """Import a module or a package using an alias for it.
+
+    For packages, this function will recursively import all its subpackages and modules.
+    """
+    sys.modules[alias] = module = importlib.import_module(name)
+    if hasattr(module, "__path__"):
+        for info in pkgutil.iter_modules(module.__path__):
+            aliased_import(f"{name}.{info.name}", f"{alias}.{info.name}")
+
+
+aliased_import("synchros2", alias=__name__)

--- a/bdai_ros2_wrappers/setup.py
+++ b/bdai_ros2_wrappers/setup.py
@@ -14,8 +14,9 @@ setup(
     ],
     install_requires=["setuptools"],
     maintainer="The AI Institute",
-    maintainer_email="engineering@theaiinstitute.com",
+    maintainer_email="opensource@theaiinstitute.com",
     description="The AI Institute's wrappers for ROS2",
+    tests_require=["pytest"],
     zip_safe=True,
     license="MIT",
 )

--- a/bdai_ros2_wrappers/test/test_import.py
+++ b/bdai_ros2_wrappers/test/test_import.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Boston Dynamics AI Institute Inc.  All rights reserved.
+
+import bdai_ros2_wrappers.scope
+import synchros2.scope
+
+
+def test_submodule_aliasing() -> None:
+    assert id(bdai_ros2_wrappers.scope) == id(synchros2.scope)
+
+
+def test_global_aliasing() -> None:
+    with bdai_ros2_wrappers.scope.top(global_=True) as top:
+        assert synchros2.scope.current() is top

--- a/synchros2/setup.py
+++ b/synchros2/setup.py
@@ -15,7 +15,7 @@ setup(
     ],
     install_requires=["setuptools"],
     maintainer="The AI Institute",
-    maintainer_email="engineering@theaiinstitute.com",
+    maintainer_email="opensource@theaiinstitute.com",
     description="The AI Institute's wrappers for ROS2",
     tests_require=["pytest"],
     zip_safe=True,


### PR DESCRIPTION
## Proposed changes

<!-- 
    A brief description of the changes you are making. 
    Make sure to refer to the issue that explains and
    motivates this patch.
-->
Follow-up to #133. This one caught me off guard. It turns out it's not enough to alias the top-level package, otherwise CPython will liberally duplicate subpackages and modules, wreaking havoc in any code that relies on globals (like `synchros2.scope` and `synchros2.process`).

Thus, this patch eagerly and recursively imports and aliases `synchros2` and all its subpackages and modules. This effectively makes `import bdai_ros2_wrappers` a slower operation, but the penalty is not significant and we will eventually deprecate and remove this alias.

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [x] Lint and unit tests pass locally
- [x] I have added tests that prove my changes are effective
- [x] I have added necessary documentation to communicate the changes
