### PR TITLE
[SW-1624] Deprecate old wrapper name

### DIFF
--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/__init__.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/__init__.py
@@ -3,14 +3,16 @@
 import importlib
 import pkgutil
 import sys
+import warnings
 
-from bdai.deprecation import deprecated
-
-
-@deprecated(
-    reason="bdai_ros2_wrappers has been renamed to synchros2. Please use the renamed version",
-    alternative="synchros2",
+warnings.simplefilter("default")
+warnings.warn(
+    "bdai_ros2_wrappers has been renamed to synchros2. Please use the new name synchros2 instead",
+    DeprecationWarning,
+    stacklevel=2,
 )
+
+
 def aliased_import(name, alias):
     """Import a module or a package using an alias for it.
 

--- a/bdai_ros2_wrappers/bdai_ros2_wrappers/__init__.py
+++ b/bdai_ros2_wrappers/bdai_ros2_wrappers/__init__.py
@@ -4,7 +4,13 @@ import importlib
 import pkgutil
 import sys
 
+from bdai.deprecation import deprecated
 
+
+@deprecated(
+    reason="bdai_ros2_wrappers has been renamed to synchros2. Please use the renamed version",
+    alternative="synchros2",
+)
 def aliased_import(name, alias):
     """Import a module or a package using an alias for it.
 


### PR DESCRIPTION
## Proposed changes

Deprecate the old name `bdai_ros2_wrappers` for new name `synchros2`

`test_import.py` still passes and prints expected deprecation message

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [ ] Lint and unit tests pass locally
- [ ] I have added tests that prove my changes are effective
- [ ] I have added necessary documentation to communicate the changes

### Additional comments

<!-- Anything else worth mentioning. -->
