### PR TITLE
[SW-1712] Pin ubuntu version in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   lint:
     name: Lint ros_utilities packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
         uses: pre-commit/action@v3.0.0
   prepare_container:
     name: Prepare Humble container for tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: lint
     permissions:
       contents: read
@@ -74,7 +74,7 @@ jobs:
           cache-to: type=gha,mode=max
   build_and_test:
     name: Build and test ros_utilities packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prepare_container
     container:
       image: ${{ needs.prepare_container.outputs.image }}

--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   clean-ghcr:
     name: Prune old images from Github Container Registry
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Delete old pull request images
         uses: snok/container-retention-policy@v2


### PR DESCRIPTION
## Change Overview

This is simply a find/replace of `ubuntu-latest` -> `ubuntu-22.04`.  Because `ubuntu-latest` will become 24.04 soon.  We should pin to 22.04 which matches our development environment.

## Testing Done

None. This PR is the test.  (Assuming this repo has CI)

