### PR TITLE
Use up-to-date OSRF Humble base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 ARG ROS_DISTRO=humble
-FROM ros:${ROS_DISTRO}-ros-base
+FROM osrf/ros:${ROS_DISTRO}-desktop
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
## Proposed changes

This patch moves our dev container and CI workflows currently away from Docker official [ROS base images](https://hub.docker.com/layers/library/ros/humble-ros-base/images/sha256-b7cf7c4046fa3d89d06e305fc81f2b45c6acbd04568c50f63955574b8b5a0b7c) and towards OSRF managed [images](https://hub.docker.com/layers/osrf/ros/humble-desktop/images/sha256-2e1181a7c79e46f9468104520b22b31260f31173f2b7d030d7fe68b9f84f78b0). It turns out that the former don't track the latest of for each ROS distribution as closely as the latter.

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [ ] Lint and unit tests pass locally
- [ ] I have added tests that prove my changes are effective
- [ ] I have added necessary documentation to communicate the changes

### Additional comments

Note that OSRF images are larger (1GB) than Docker official ones (~290MB). 