### PR TITLE
Upgrade Humble packages in base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 SHELL ["/bin/bash", "-c"]
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
-    apt-get update -q && \
+    apt-get dist-upgrade -y --no-install-recommends && \
     apt-get install -yq --no-install-recommends \
     python3-pip \
     python-is-python3 \


### PR DESCRIPTION
## Proposed changes

Alternative to #149. Keeps official Docker ROS images but `apt dist-upgrade`s them.

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [x] Lint and unit tests pass locally
- [x] ~I have added tests that prove my changes are effective~
- [x] ~I have added necessary documentation to communicate the changes~
