### PR TITLE
Handle concurrent context shutdowns

### DIFF
--- a/synchros2/synchros2/scope.py
+++ b/synchros2/synchros2/scope.py
@@ -533,12 +533,16 @@ def top(  # noqa: D417
         # aware, and thus a shutdown will unblock them.
         if global_:
             default_context = rclpy.utilities.get_default_context(shutting_down=True)
-            default_context.try_shutdown()
+            with contextlib.suppress(RuntimeError):
+                default_context.try_shutdown()
+
             if not interruptible:
                 rclpy.signals.uninstall_signal_handlers()
         else:
             assert context is not None
-            context.try_shutdown()
+            with contextlib.suppress(RuntimeError):
+                context.try_shutdown()
+
         stack.close()
 
 


### PR DESCRIPTION
## Proposed changes

This patch mitigates https://github.com/ros2/rclpy/issues/1352. Unfortunately `rclpy.Context.try_shutdown()` is not entirely safe when both threads and signal handlers enter the equation.

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [x] Lint and unit tests pass locally
- [ ] ~I have added tests that prove my changes are effective~ Hard to reproduce, failure mode require a race
- [ ] ~I have added necessary documentation to communicate the changes~ This is the proper functionality here